### PR TITLE
[WIP] Add OpenSDS CI test script into openlab zuul jobs

### DIFF
--- a/playbooks/opensds-acceptance-test/run.yaml
+++ b/playbooks/opensds-acceptance-test/run.yaml
@@ -1,0 +1,63 @@
+- hosts: all
+  become: yes
+  tasks:
+
+    - shell:
+        cmd: |
+          set -e
+          set -x
+          cat << 'EOF' >>"/tmp/dg-local.conf"
+          [[local|localrc]]
+          # pass
+
+          EOF
+        executable: /bin/bash
+        chdir: '{{ ansible_user_dir }}/workspace'
+      environment: '{{ zuul | zuul_legacy_vars }}'
+
+    - shell:
+        cmd: |
+          set -e
+          set -x
+          export PYTHONUNBUFFERED=true
+          export GIT_BASE=https://github.com
+          cp devstack-gate/devstack-vm-gate-wrap.sh ./safe-devstack-vm-gate-wrap.sh
+          ./safe-devstack-vm-gate-wrap.sh
+        executable: /bin/bash
+        chdir: '{{ ansible_user_dir }}/workspace'
+      environment: '{{ zuul | zuul_legacy_vars }}'
+
+    - shell:
+        cmd: |
+          set -e
+          set -x
+          wget -c https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz
+          sudo tar -C /usr/local/ -xvzf go1.9.linux-amd64.tar.gz
+
+          # Install env variables
+          export GOPATH={{ ansible_user_dir }}
+          mkdir -p $GOPATH/{bin,pkg}
+          export PATH=$PATH:$GOPATH/bin:/usr/local/go/bin
+          export GOBIN=$GOPATH/bin
+          export OPENSDS_DIR=$GOPATH/src/github.com/opensds
+          export OPENSDS_ROOT=$OPENSDS_DIR/opensds
+
+          # OpenSDS Download and Build
+          if [ ! -d $OPENSDS_DIR ]; then
+            mkdir -p $OPENSDS_DIR
+          fi
+          cd $OPENSDS_DIR
+          if [ ! -d $OPENSDS_ROOT ]; then
+            git clone https://github.com/opensds/opensds.git -b development
+          fi
+          cd $OPENSDS_ROOT
+          if [ ! -d $OPENSDS_ROOT/build ]; then
+            make
+          fi
+
+          # Start integration test.		
+          sudo ./test/integration/prepare.sh
+          go test -v github.com/opensds/opensds/test/integration/... -tags integration
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
+      environment: '{{ zuul | zuul_legacy_vars }}'

--- a/playbooks/opensds-unittest/run.yaml
+++ b/playbooks/opensds-unittest/run.yaml
@@ -1,0 +1,38 @@
+- name: Run opensds unit test
+  hosts: all
+  roles:
+    - ensure-legacy-workspace-directory
+  tasks:
+
+    - shell:
+        cmd: |
+          set -e
+          set -x
+          wget -c https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz
+          sudo tar -C /usr/local/ -xvzf go1.9.linux-amd64.tar.gz
+
+          # Install env variables
+          export GOPATH={{ ansible_user_dir }}
+          mkdir -p $GOPATH/{bin,pkg}
+          export PATH=$PATH:$GOPATH/bin:/usr/local/go/bin
+          export GOBIN=$GOPATH/bin
+          export OPENSDS_DIR=$GOPATH/src/github.com/opensds
+          export OPENSDS_ROOT=$OPENSDS_DIR/opensds
+
+          # OpenSDS Download
+          if [ ! -d $OPENSDS_DIR ]; then
+            mkdir -p $OPENSDS_DIR
+          fi
+          cd $OPENSDS_DIR
+          if [ ! -d $OPENSDS_ROOT ]; then
+            git clone https://github.com/opensds/opensds.git -b development
+          fi
+          cd $OPENSDS_ROOT
+
+          # Start unit test.
+          go test -v github.com/opensds/opensds/client/... -cover
+          go test -v github.com/opensds/opensds/pkg/... -cover
+          go test -v github.com/opensds/opensds/contrib/... -cover
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
+      environment: '{{ zuul | zuul_legacy_vars }}'


### PR DESCRIPTION
## Motivation
[OpenSDS](https://github.com/opensds) is an open source community working to address storage integration challenges, particularly in scale-out cloud native environments with heterogeneous storage platforms. Since OpenStack is working on cross-community integration and testing, IMO OpenSDS could act a great binder when OpenStack integrating with other communities (such as Kubernetes) in storage management field for several reasons below:
1.	Provide a universal user centric high level storage abstraction API
2.	Provide descriptive profiles (collection of policies) for users
3.	Fix some gaps in storage feature between Cinder and Kubernetes storage driver

Since OpenLab is working on cross-projects CI and testing, I suggest we could finish the integration work between OpenSDS [Controller](https://github.com/opensds/opensds) Project and OpenLab firstly.

## Work Process
Since I'm not quite familiar with this tool, to ruduce the resource cost, I only submitted unit test and acceptance test of OpenSDS in this patch. Besides, I'm working on configuring the CI app (on OpenSDS repo) and adding opsds-provider-openstack-acceptance-test-* script.

Thank you for watching this, and more suggestions are welcomed.