### PR TITLE
Set OS_IDENTITY_API_VERSION=3 in Mitaka jobs

### DIFF
--- a/playbooks/gophercloud-acceptance-test-mitaka/run.yaml
+++ b/playbooks/gophercloud-acceptance-test-mitaka/run.yaml
@@ -61,6 +61,9 @@
           echo export OS_FLAVOR_ID=99 >> openrc
           echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
           echo export OS_SHARE_NETWORK_ID=foobar >> openrc
+          # Default value is 2.0 in Mitaka, and 2.0 API will be deprecated
+          # in the future, test against V3 API in stead
+          echo export OS_IDENTITY_API_VERSION=3 >> openrc
           source openrc admin admin
           popd
 

--- a/playbooks/terraform-provider-openstack-acceptance-test-mitaka/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-mitaka/run.yaml
@@ -64,6 +64,9 @@
           echo export OS_FLAVOR_ID=99 >> openrc
           echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
           echo export OS_SHARE_NETWORK_ID=foobar >> openrc
+          # Default value is 2.0 in Mitaka, and 2.0 API will be deprecated
+          # in the future, test against V3 API in stead
+          echo export OS_IDENTITY_API_VERSION=3 >> openrc
           source openrc demo demo
           popd
 


### PR DESCRIPTION
The default value of OS_IDENTITY_API_VERSION is 2.0 in Mitaka devstack,
but V2.0 API of keystone will be deprecated in the future, test against
V3 API of keystone in jobs to keep it ok.