### PR TITLE
Set OS_AUTH_URL point to v3 URL in Mitaka jobs

### DIFF
--- a/playbooks/gophercloud-acceptance-test-mitaka/run.yaml
+++ b/playbooks/gophercloud-acceptance-test-mitaka/run.yaml
@@ -62,8 +62,9 @@
           echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
           echo export OS_SHARE_NETWORK_ID=foobar >> openrc
           # Default value is 2.0 in Mitaka, and 2.0 API will be deprecated
-          # in the future, test against V3 API in stead
+          # in the future, test against V3 API in stead.
           echo export OS_IDENTITY_API_VERSION=3 >> openrc
+          echo export OS_AUTH_URL=${OS_AUTH_URL/v2.0/v3} >> openrc
           source openrc admin admin
           popd
 

--- a/playbooks/terraform-provider-openstack-acceptance-test-mitaka/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-mitaka/run.yaml
@@ -65,8 +65,9 @@
           echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
           echo export OS_SHARE_NETWORK_ID=foobar >> openrc
           # Default value is 2.0 in Mitaka, and 2.0 API will be deprecated
-          # in the future, test against V3 API in stead
+          # in the future, test against V3 API in stead.
           echo export OS_IDENTITY_API_VERSION=3 >> openrc
+          echo export OS_AUTH_URL=${OS_AUTH_URL/v2.0/v3} >> openrc
           source openrc demo demo
           popd
 


### PR DESCRIPTION
The default value of OS_AUTH_URL looks like http://localhost:5000/v2.0,
set it point to v3 URL in Mitaka jobs http://localhost:5000/v3