### PR TITLE
Add OS_DOMAIN_NAME option for Mitaka jobs

### DIFF
--- a/playbooks/gophercloud-acceptance-test-mitaka/run.yaml
+++ b/playbooks/gophercloud-acceptance-test-mitaka/run.yaml
@@ -65,6 +65,7 @@
           # in the future, test against V3 API in stead.
           echo export OS_IDENTITY_API_VERSION=3 >> openrc
           echo export OS_AUTH_URL=${OS_AUTH_URL/v2.0/v3} >> openrc
+          echo export OS_DOMAIN_NAME=Default >> openrc
           source openrc admin admin
           popd
 

--- a/playbooks/gophercloud-acceptance-test-newton/run.yaml
+++ b/playbooks/gophercloud-acceptance-test-newton/run.yaml
@@ -61,6 +61,7 @@
           echo export OS_FLAVOR_ID=99 >> openrc
           echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
           echo export OS_SHARE_NETWORK_ID=foobar >> openrc
+          echo export OS_DOMAIN_NAME=Default >> openrc
           source openrc admin admin
           popd
 

--- a/playbooks/terraform-provider-openstack-acceptance-test-mitaka/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-mitaka/run.yaml
@@ -68,6 +68,7 @@
           # in the future, test against V3 API in stead.
           echo export OS_IDENTITY_API_VERSION=3 >> openrc
           echo export OS_AUTH_URL=${OS_AUTH_URL/v2.0/v3} >> openrc
+          echo export OS_DOMAIN_NAME=Default >> openrc
           source openrc demo demo
           popd
 

--- a/playbooks/terraform-provider-openstack-acceptance-test-newton/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-newton/run.yaml
@@ -64,6 +64,7 @@
           echo export OS_FLAVOR_ID=99 >> openrc
           echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
           echo export OS_SHARE_NETWORK_ID=foobar >> openrc
+          echo export OS_DOMAIN_NAME=Default >> openrc
           source openrc demo demo
           popd
 

--- a/playbooks/terraform-provider-openstack-acceptance-test-ocata/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-ocata/run.yaml
@@ -62,6 +62,7 @@
           echo export OS_FLAVOR_ID=99 >> openrc
           echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
           echo export OS_SHARE_NETWORK_ID=foobar >> openrc
+          echo export OS_DOMAIN_NAME=Default >> openrc
           source openrc demo demo
           popd
 

--- a/playbooks/terraform-provider-openstack-acceptance-test-pike/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-pike/run.yaml
@@ -62,6 +62,7 @@
           echo export OS_FLAVOR_ID=99 >> openrc
           echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
           echo export OS_SHARE_NETWORK_ID=foobar >> openrc
+          echo export OS_DOMAIN_NAME=Default >> openrc
           source openrc demo demo
           popd
 

--- a/playbooks/terraform-provider-openstack-acceptance-test/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test/run.yaml
@@ -61,6 +61,7 @@
           echo export OS_FLAVOR_ID=99 >> openrc
           echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
           echo export OS_SHARE_NETWORK_ID=foobar >> openrc
+          echo export OS_DOMAIN_NAME=Default >> openrc
           source openrc demo demo
           popd
 


### PR DESCRIPTION
We use Keystone V3 API in all the jobs, so OS_DOMAIN_NAME is back