### PR TITLE
Ensure source directory exists to avoid cp fail

### DIFF
--- a/playbooks/gophercloud-unittest/run.yaml
+++ b/playbooks/gophercloud-unittest/run.yaml
@@ -7,7 +7,7 @@
           set -x
 
           if [[ ! -d $GOPATH/src/github.com/gophercloud/gophercloud/ && -d $GOPATH/src/github.com/theopenlab/gophercloud ]]; then
-              echo "Warnning: this is a temporary workaround because this job is not triggered from official git repo."
+              echo "Warning: this is a temporary workaround because this job is not triggered from official git repo."
               mkdir -p $GOPATH/src/github.com/gophercloud/
               cp -r $GOPATH/src/github.com/theopenlab/gophercloud  $GOPATH/src/github.com/gophercloud/
               cd $GOPATH/src/github.com/gophercloud/gophercloud

--- a/playbooks/gophercloud-unittest/run.yaml
+++ b/playbooks/gophercloud-unittest/run.yaml
@@ -6,7 +6,7 @@
           set -o pipefail
           set -x
 
-          if [[ ! -d $GOPATH/src/github.com/gophercloud/gophercloud/ ]]; then
+          if [[ ! -d $GOPATH/src/github.com/gophercloud/gophercloud/ && -d $GOPATH/src/github.com/theopenlab/gophercloud ]]; then
               echo "Warnning: this is a temporary workaround because this job is not triggered from official git repo."
               mkdir -p $GOPATH/src/github.com/gophercloud/
               cp -r $GOPATH/src/github.com/theopenlab/gophercloud  $GOPATH/src/github.com/gophercloud/

--- a/playbooks/terraform-provider-flexibleengine-acceptance-test-orange/run.yaml
+++ b/playbooks/terraform-provider-flexibleengine-acceptance-test-orange/run.yaml
@@ -45,7 +45,7 @@
           set -x
 
           # Run acc test
-          if [[ ! -d $GOPATH/src/github.com/Karajan-project/terraform-provider-flexibleengine/ ]]; then
+          if [[ ! -d $GOPATH/src/github.com/Karajan-project/terraform-provider-flexibleengine/ && -d $GOPATH/src/github.com/animationzl/terraform-provider-flexibleengine ]]; then
               echo "Warnning: this is a temporary workaround because this job is not triggered from official git repo."
               mkdir -p $GOPATH/src/github.com/Karajan-project/
               cp -r $GOPATH/src/github.com/animationzl/terraform-provider-flexibleengine  $GOPATH/src/github.com/Karajan-project/

--- a/playbooks/terraform-provider-flexibleengine-acceptance-test-orange/run.yaml
+++ b/playbooks/terraform-provider-flexibleengine-acceptance-test-orange/run.yaml
@@ -46,7 +46,7 @@
 
           # Run acc test
           if [[ ! -d $GOPATH/src/github.com/Karajan-project/terraform-provider-flexibleengine/ && -d $GOPATH/src/github.com/animationzl/terraform-provider-flexibleengine ]]; then
-              echo "Warnning: this is a temporary workaround because this job is not triggered from official git repo."
+              echo "Warning: this is a temporary workaround because this job is not triggered from official git repo."
               mkdir -p $GOPATH/src/github.com/Karajan-project/
               cp -r $GOPATH/src/github.com/animationzl/terraform-provider-flexibleengine  $GOPATH/src/github.com/Karajan-project/
               cd $GOPATH/src/github.com/Karajan-project/terraform-provider-flexibleengine

--- a/playbooks/terraform-provider-openstack-acceptance-test-designate/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-designate/run.yaml
@@ -34,7 +34,7 @@
 
           # Run acc test
           if [[ ! -d $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack/ && -d $GOPATH/src/github.com/theopenlab/terraform-provider-openstack ]]; then
-              echo "Warnning: this is a temporary workaround because this job is not triggered from official git repo."
+              echo "Warning: this is a temporary workaround because this job is not triggered from official git repo."
               mkdir -p $GOPATH/src/github.com/terraform-providers/
               cp -r $GOPATH/src/github.com/theopenlab/terraform-provider-openstack  $GOPATH/src/github.com/terraform-providers/
               cd $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack

--- a/playbooks/terraform-provider-openstack-acceptance-test-designate/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-designate/run.yaml
@@ -33,7 +33,7 @@
           popd
 
           # Run acc test
-          if [[ ! -d $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack/ ]]; then
+          if [[ ! -d $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack/ && -d $GOPATH/src/github.com/theopenlab/terraform-provider-openstack ]]; then
               echo "Warnning: this is a temporary workaround because this job is not triggered from official git repo."
               mkdir -p $GOPATH/src/github.com/terraform-providers/
               cp -r $GOPATH/src/github.com/theopenlab/terraform-provider-openstack  $GOPATH/src/github.com/terraform-providers/

--- a/playbooks/terraform-provider-openstack-acceptance-test-trove/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-trove/run.yaml
@@ -75,7 +75,7 @@
           iptables -D openstack-INPUT -j REJECT --reject-with icmp-host-prohibited || true
 
           if [[ ! -d $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack/ && -d $GOPATH/src/github.com/theopenlab/terraform-provider-openstack ]]; then
-              echo "Warnning: this is a temporary workaround because this job is not triggered from official git repo."
+              echo "Warning: this is a temporary workaround because this job is not triggered from official git repo."
               mkdir -p $GOPATH/src/github.com/terraform-providers/
               cp -r $GOPATH/src/github.com/theopenlab/terraform-provider-openstack  $GOPATH/src/github.com/terraform-providers/
               cd $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack

--- a/playbooks/terraform-provider-openstack-acceptance-test-trove/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-trove/run.yaml
@@ -74,7 +74,7 @@
           # Fix iptables rules that prevent amqp connections from the devstack box to the guests
           iptables -D openstack-INPUT -j REJECT --reject-with icmp-host-prohibited || true
 
-          if [[ ! -d $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack/ ]]; then
+          if [[ ! -d $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack/ && -d $GOPATH/src/github.com/theopenlab/terraform-provider-openstack ]]; then
               echo "Warnning: this is a temporary workaround because this job is not triggered from official git repo."
               mkdir -p $GOPATH/src/github.com/terraform-providers/
               cp -r $GOPATH/src/github.com/theopenlab/terraform-provider-openstack  $GOPATH/src/github.com/terraform-providers/

--- a/playbooks/terraform-provider-openstack-acceptance-test/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test/run.yaml
@@ -34,7 +34,7 @@
 
           # Run acc test
           if [[ ! -d $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack/ && -d $GOPATH/src/github.com/theopenlab/terraform-provider-openstack ]]; then
-              echo "Warnning: this is a temporary workaround because this job is not triggered from official git repo."
+              echo "Warning: this is a temporary workaround because this job is not triggered from official git repo."
               mkdir -p $GOPATH/src/github.com/terraform-providers/
               cp -r $GOPATH/src/github.com/theopenlab/terraform-provider-openstack  $GOPATH/src/github.com/terraform-providers/
               cd $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack

--- a/playbooks/terraform-provider-openstack-acceptance-test/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test/run.yaml
@@ -33,7 +33,7 @@
           popd
 
           # Run acc test
-          if [[ ! -d $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack/ ]]; then
+          if [[ ! -d $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack/ && -d $GOPATH/src/github.com/theopenlab/terraform-provider-openstack ]]; then
               echo "Warnning: this is a temporary workaround because this job is not triggered from official git repo."
               mkdir -p $GOPATH/src/github.com/terraform-providers/
               cp -r $GOPATH/src/github.com/theopenlab/terraform-provider-openstack  $GOPATH/src/github.com/terraform-providers/

--- a/playbooks/terraform-provider-openstack-unittest/run.yaml
+++ b/playbooks/terraform-provider-openstack-unittest/run.yaml
@@ -9,7 +9,7 @@
 
           # Run unit test
           if [[ ! -d $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack/ && -d $GOPATH/src/github.com/theopenlab/terraform-provider-openstack ]]; then
-              echo "Warnning: this is a temporary workaround because this job is not triggered from official git repo."
+              echo "Warning: this is a temporary workaround because this job is not triggered from official git repo."
               mkdir -p $GOPATH/src/github.com/terraform-providers/
               cp -r $GOPATH/src/github.com/theopenlab/terraform-provider-openstack  $GOPATH/src/github.com/terraform-providers/
               cd $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack

--- a/playbooks/terraform-provider-openstack-unittest/run.yaml
+++ b/playbooks/terraform-provider-openstack-unittest/run.yaml
@@ -8,7 +8,7 @@
           set -x
 
           # Run unit test
-          if [[ ! -d $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack/ ]]; then
+          if [[ ! -d $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack/ && -d $GOPATH/src/github.com/theopenlab/terraform-provider-openstack ]]; then
               echo "Warnning: this is a temporary workaround because this job is not triggered from official git repo."
               mkdir -p $GOPATH/src/github.com/terraform-providers/
               cp -r $GOPATH/src/github.com/theopenlab/terraform-provider-openstack  $GOPATH/src/github.com/terraform-providers/

--- a/playbooks/terraform-provider-telefonicaopencloud-acceptance-test-telefonica/run.yaml
+++ b/playbooks/terraform-provider-telefonicaopencloud-acceptance-test-telefonica/run.yaml
@@ -44,7 +44,7 @@
           set -x
 
           if [[ ! -d $GOPATH/src/github.com/huawei-clouds/terraform-provider-telefonicaopencloud/ && -d $GOPATH/src/github.com/liu-sheng/terraform-provider-telefonicaopencloud ]]; then
-              echo "Warnning: this is a temporary workaround because this job is not triggered from official git repo."
+              echo "Warning: this is a temporary workaround because this job is not triggered from official git repo."
               mkdir -p $GOPATH/src/github.com/huawei-clouds/
               cp -r $GOPATH/src/github.com/liu-sheng/terraform-provider-telefonicaopencloud  $GOPATH/src/github.com/huawei-clouds/
               cd $GOPATH/src/github.com/huawei-clouds/terraform-provider-telefonicaopencloud/

--- a/playbooks/terraform-provider-telefonicaopencloud-acceptance-test-telefonica/run.yaml
+++ b/playbooks/terraform-provider-telefonicaopencloud-acceptance-test-telefonica/run.yaml
@@ -43,7 +43,7 @@
           set -o pipefail
           set -x
 
-          if [[ ! -d $GOPATH/src/github.com/huawei-clouds/terraform-provider-telefonicaopencloud/ ]]; then
+          if [[ ! -d $GOPATH/src/github.com/huawei-clouds/terraform-provider-telefonicaopencloud/ && -d $GOPATH/src/github.com/liu-sheng/terraform-provider-telefonicaopencloud ]]; then
               echo "Warnning: this is a temporary workaround because this job is not triggered from official git repo."
               mkdir -p $GOPATH/src/github.com/huawei-clouds/
               cp -r $GOPATH/src/github.com/liu-sheng/terraform-provider-telefonicaopencloud  $GOPATH/src/github.com/huawei-clouds/


### PR DESCRIPTION
Currently we have to copy forked project directory to offical
project directory for verifying CI trigger. Add the check to
avoid copy fail when source directory don't exists.

The copy failing maybe happen when we run devstack backend job on specific backend SDK/Tools project, like: http://logs.openlabtesting.org/logs/8/8/c8184f6fb3609bf38ca96736d9cd721e5e16ffb7/check/terraform-provider-openstack-acceptance-test/8cec66e/