### PR TITLE
Add OS_DOMAIN_NAME into openrc

### DIFF
--- a/playbooks/terraform-provider-openstack-acceptance-test/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test/run.yaml
@@ -32,6 +32,7 @@
           echo export OS_FLAVOR_ID=99 >> openrc
           echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
           echo export OS_SHARE_NETWORK_ID=foobar >> openrc
+          echo export OS_DOMAIN_NAME=Default >> openrc
           source openrc demo demo
           popd
 


### PR DESCRIPTION
In mitaka the default keystone endpoint is v2 API, we enable v3 API
in test jobs manually, so OS_DOMAIN_NAME should be added into openrc
in order to auth success. In other version(N/O/P) devstack have added
related domain options into openrc.