### PR TITLE
Add OS_DOMAIN_ID=default into devstack openrc

### DIFF
--- a/playbooks/gophercloud-acceptance-test/run.yaml
+++ b/playbooks/gophercloud-acceptance-test/run.yaml
@@ -32,7 +32,7 @@
           echo export OS_FLAVOR_ID=99 >> openrc
           echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
           echo export OS_SHARE_NETWORK_ID=foobar >> openrc
-          echo export OS_DOMAIN_NAME=Default >> openrc
+          echo export OS_DOMAIN_ID=default >> openrc
           source openrc admin admin
           popd
 

--- a/playbooks/terraform-provider-openstack-acceptance-test/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test/run.yaml
@@ -32,7 +32,7 @@
           echo export OS_FLAVOR_ID=99 >> openrc
           echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
           echo export OS_SHARE_NETWORK_ID=foobar >> openrc
-          echo export OS_DOMAIN_NAME=Default >> openrc
+          echo export OS_DOMAIN_ID=default >> openrc
           source openrc demo demo
           popd
 


### PR DESCRIPTION
Gophercloud pick environment variable OS_DOMAIN_ID and OS_DOMAIN_NAME,
Terraform-openstack-provider pick OS_DOMAIN_ID, OS_USER_DOMAIN_ID,
OS_PROJECT_DOMAIN_ID, OS_DOMAIN_NAME, OS_USER_DOMAIN_NAME,
OS_PROJECT_DOMAIN_NAME, and both ID and Name can't be empty or
specified. So purpose to specify OS_DOMAIN_ID=default in openrc,
that can override the options OS_USER_DOMAIN_ID and
OS_PROJECT_DOMAIN_NAME in the release after Mitaka.

Fixes #24