### PR TITLE
Support separate LBaaS tests for terraform-openstack-provider

### DIFF
--- a/playbooks/terraform-provider-openstack-acceptance-test-lbaas/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-lbaas/run.yaml
@@ -1,0 +1,52 @@
+- hosts: all
+  become: yes
+  roles:
+    - clone-devstack-gate-to-workspace
+    - role: create-devstack-local-conf
+      enable_services:
+        - 'lbaas'
+    - install-devstack
+  tasks:
+    - shell:
+        cmd: |
+          set -e
+          set -o pipefail
+          set -x
+
+          # Prep the testing environment by creating the required testing resources and environment variables
+          pushd /opt/stack/new/devstack
+          source openrc admin admin
+          openstack flavor create m1.acctest --id 99 --ram 512 --disk 5 --vcpu 1 --ephemeral 10
+          openstack flavor create m1.resize --id 98 --ram 512 --disk 6 --vcpu 1 --ephemeral 10
+          _NETWORK_ID=$(openstack network show private -c id -f value)
+          _EXTGW_ID=$(openstack network show public -c id -f value)
+          _IMAGE=$(openstack image list | grep -i cirros | head -n 1)
+          _IMAGE_ID=$(echo $_IMAGE | awk -F\| '{print $2}' | tr -d ' ')
+          _IMAGE_NAME=$(echo $_IMAGE | awk -F\| '{print $3}' | tr -d ' ')
+          echo export OS_IMAGE_NAME="$_IMAGE_NAME" >> openrc
+          echo export OS_IMAGE_ID="$_IMAGE_ID" >> openrc
+          echo export OS_NETWORK_ID=$_NETWORK_ID >> openrc
+          echo export OS_EXTGW_ID=$_EXTGW_ID >> openrc
+          echo export OS_POOL_NAME="public" >> openrc
+          echo export OS_FLAVOR_ID=99 >> openrc
+          echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
+          echo export OS_SHARE_NETWORK_ID=foobar >> openrc
+          source openrc demo demo
+          popd
+
+          # Run acc test
+          if [[ ! -d $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack/ && -d $GOPATH/src/github.com/theopenlab/terraform-provider-openstack ]]; then
+              echo "Warning: this is a temporary workaround because this job is not triggered from official git repo."
+              mkdir -p $GOPATH/src/github.com/terraform-providers/
+              cp -r $GOPATH/src/github.com/theopenlab/terraform-provider-openstack  $GOPATH/src/github.com/terraform-providers/
+              cd $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack
+          fi
+
+          # Run the LB test 100 testcases at a time
+          export OS_LB_ENVIRONMENT=1 # for LBaaS tests
+          testcases=`go test ./openstack/ -v -list 'Acc'`
+          testcases=`echo "$testcases" | sed '$d' | grep LB`
+          echo "$testcases" | xargs -t -n100 sh -c 'TF_LOG=DEBUG TF_ACC=1 go test ./openstack -v -timeout 120m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
+      environment: '{{ golang_env }}'

--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -80,3 +80,19 @@
   environment: '{{ zuul | zuul_legacy_vars }}'
   when:
     - '"designate" in enable_services'
+
+- name: create devstack local conf with lbaas enabled
+  shell:
+    cmd: |
+      set -e
+      set -x
+      cat << EOF >> /tmp/dg-local.conf
+      enable_service octavia,o-cw,o-hm,o-hk,o-api
+      enable_plugin octavia https://git.openstack.org/openstack/octavia
+      enable_plugin barbican https://git.openstack.org/openstack/barbican
+      EOF
+    executable: /bin/bash
+    chdir: '{{ ansible_user_dir }}/workspace'
+  environment: '{{ zuul | zuul_legacy_vars }}'
+  when:
+    - '"lbaas" in enable_services'

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -146,6 +146,13 @@
       Run terraform-provider-openstack trove acceptance test on master branch
     run: playbooks/terraform-provider-openstack-acceptance-test-trove/run.yaml
 
+- job:
+    name: terraform-provider-openstack-acceptance-test-lbaas
+    parent: golang-test
+    description: |
+      Run terraform provider openstack lbaas acceptance test on master branch
+    run: playbooks/terraform-provider-openstack-acceptance-test-lbaas/run.yaml
+
 # Gophercloud acceptance tests with Telefonica cloud
 - job:
     name: gophercloud-acceptance-test-telefonica


### PR DESCRIPTION
By default, we deploy OpenStack that include all of the core services
(Nova, Neutron, Cinder, Keystone, Glance, Swift). Some other services
also are used by lots of users, like: designate, trove, LBaaS, Octavia.

Purpose to enable LBaaS + Octavia services, and run related acceptance
tests for terraform-openstack-provider.

Part of https://github.com/orgs/theopenlab/projects/1#card-6800912

Fixes #32