### PR TITLE
Support separate FWaaS tests for terraform-openstack-provider

### DIFF
--- a/playbooks/terraform-provider-openstack-acceptance-test-fwaas/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-fwaas/run.yaml
@@ -1,0 +1,52 @@
+- hosts: all
+  become: yes
+  roles:
+    - clone-devstack-gate-to-workspace
+    - role: create-devstack-local-conf
+      enable_services:
+        - 'fwaas'
+    - install-devstack
+  tasks:
+    - shell:
+        cmd: |
+          set -e
+          set -o pipefail
+          set -x
+
+          # Prep the testing environment by creating the required testing resources and environment variables
+          pushd /opt/stack/new/devstack
+          source openrc admin admin
+          openstack flavor create m1.acctest --id 99 --ram 512 --disk 5 --vcpu 1 --ephemeral 10
+          openstack flavor create m1.resize --id 98 --ram 512 --disk 6 --vcpu 1 --ephemeral 10
+          _NETWORK_ID=$(openstack network show private -c id -f value)
+          _EXTGW_ID=$(openstack network show public -c id -f value)
+          _IMAGE=$(openstack image list | grep -i cirros | head -n 1)
+          _IMAGE_ID=$(echo $_IMAGE | awk -F\| '{print $2}' | tr -d ' ')
+          _IMAGE_NAME=$(echo $_IMAGE | awk -F\| '{print $3}' | tr -d ' ')
+          echo export OS_IMAGE_NAME="$_IMAGE_NAME" >> openrc
+          echo export OS_IMAGE_ID="$_IMAGE_ID" >> openrc
+          echo export OS_NETWORK_ID=$_NETWORK_ID >> openrc
+          echo export OS_EXTGW_ID=$_EXTGW_ID >> openrc
+          echo export OS_POOL_NAME="public" >> openrc
+          echo export OS_FLAVOR_ID=99 >> openrc
+          echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
+          echo export OS_SHARE_NETWORK_ID=foobar >> openrc
+          source openrc demo demo
+          popd
+
+          # Run acc test
+          if [[ ! -d $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack/ && -d $GOPATH/src/github.com/theopenlab/terraform-provider-openstack ]]; then
+              echo "Warning: this is a temporary workaround because this job is not triggered from official git repo."
+              mkdir -p $GOPATH/src/github.com/terraform-providers/
+              cp -r $GOPATH/src/github.com/theopenlab/terraform-provider-openstack  $GOPATH/src/github.com/terraform-providers/
+              cd $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack
+          fi
+
+          # Run the FWaaS test 100 testcases at a time
+          export OS_FW_ENVIRONMENT=1 # for FWaaS tests
+          testcases=`go test ./openstack/ -v -list 'Acc'`
+          testcases=`echo "$testcases" | sed '$d' | grep FW`
+          echo "$testcases" | xargs -t -n100 sh -c 'TF_LOG=DEBUG TF_ACC=1 go test ./openstack -v -timeout 120m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
+      environment: '{{ golang_env }}'

--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -96,3 +96,18 @@
   environment: '{{ zuul | zuul_legacy_vars }}'
   when:
     - '"lbaas" in enable_services'
+
+- name: create devstack local conf with fwaas enabled
+  shell:
+    cmd: |
+      set -e
+      set -x
+      cat << EOF >> /tmp/dg-local.conf
+      enable_service q-fwaas-v2
+      enable_plugin neutron-fwaas https://git.openstack.org/openstack/neutron-fwaas
+      EOF
+    executable: /bin/bash
+    chdir: '{{ ansible_user_dir }}/workspace'
+  environment: '{{ zuul | zuul_legacy_vars }}'
+  when:
+    - '"fwaas" in enable_services'

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -153,6 +153,13 @@
       Run terraform provider openstack lbaas acceptance test on master branch
     run: playbooks/terraform-provider-openstack-acceptance-test-lbaas/run.yaml
 
+- job:
+    name: terraform-provider-openstack-acceptance-test-fwaas
+    parent: golang-test
+    description: |
+      Run terraform provider openstack fwaas acceptance test on master branch
+    run: playbooks/terraform-provider-openstack-acceptance-test-fwaas/run.yaml
+
 # Gophercloud acceptance tests with Telefonica cloud
 - job:
     name: gophercloud-acceptance-test-telefonica


### PR DESCRIPTION
Add job defination and Ansible script to deploy FWaaS service,
and run related terraform-openstack-provider acceptance FW tests.

Fixes: #35

Part of https://github.com/orgs/theopenlab/projects/1#card-6800912