### PR TITLE
Add Barbican into project list

### DIFF
--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -15,6 +15,7 @@
       export DEVSTACK_GATE_FIXED_RANGE=10.0.0.0/20
       export PROJECTS="openstack/designate $PROJECTS"
       export PROJECTS="openstack/python-manilaclient $PROJECTS"
+      export PROJECTS="openstack/barbican $PROJECTS"
 
       cp devstack-gate/devstack-vm-gate-wrap.sh ./safe-devstack-vm-gate-wrap.sh
       ./safe-devstack-vm-gate-wrap.sh


### PR DESCRIPTION
Barbican project should be deployed in LBaaS job, but it is not in
devstack-gate project list, that cause devstack deploying failed.

Fixes: #41