### PR TITLE
Support both FWaaS v1 and v2 in OpenLab

### DIFF
--- a/playbooks/terraform-provider-openstack-acceptance-test-fwaas/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-fwaas/run.yaml
@@ -4,7 +4,7 @@
     - clone-devstack-gate-to-workspace
     - role: create-devstack-local-conf
       enable_services:
-        - 'fwaas'
+        - 'fwaas-v1'
     - install-devstack
   tasks:
     - shell:

--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -97,7 +97,23 @@
   when:
     - '"lbaas" in enable_services'
 
-- name: create devstack local conf with fwaas enabled
+
+- name: create devstack local conf with fwaas v1 enabled
+  shell:
+    cmd: |
+      set -e
+      set -x
+      cat << EOF >> /tmp/dg-local.conf
+      enable_service q-fwaas-v1
+      enable_plugin neutron-fwaas https://git.openstack.org/openstack/neutron-fwaas
+      EOF
+    executable: /bin/bash
+    chdir: '{{ ansible_user_dir }}/workspace'
+  environment: '{{ zuul | zuul_legacy_vars }}'
+  when:
+    - '"fwaas-v1" in enable_services'
+
+- name: create devstack local conf with fwaas v2 enabled
   shell:
     cmd: |
       set -e
@@ -110,4 +126,4 @@
     chdir: '{{ ansible_user_dir }}/workspace'
   environment: '{{ zuul | zuul_legacy_vars }}'
   when:
-    - '"fwaas" in enable_services'
+    - '"fwaas-v2" in enable_services'


### PR DESCRIPTION
Some SDK/Tools project still support FWaaS v1, like
terraform-provider-openstack, even if OpenStack FWaaS team have not
added any new feature into v1. OpenLab should support to run tests
against FWaaS both v1 and v2, let SDK/Tools project to choose run which
one.

Fixes: #43