### PR TITLE
Add python-barbicanclient into PROJECTS

### DIFF
--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -15,7 +15,7 @@
       export DEVSTACK_GATE_FIXED_RANGE=10.0.0.0/20
       export PROJECTS="openstack/designate $PROJECTS"
       export PROJECTS="openstack/python-manilaclient $PROJECTS"
-      export PROJECTS="openstack/barbican $PROJECTS"
+      export PROJECTS="openstack/barbican openstack/python-barbicanclient $PROJECTS"
 
       cp devstack-gate/devstack-vm-gate-wrap.sh ./safe-devstack-vm-gate-wrap.sh
       ./safe-devstack-vm-gate-wrap.sh


### PR DESCRIPTION
python-barbicanclient should be added into PROJECTS of devstack-gate
in order to support LBaaS and Octavia installation.

Fixes: #41