### PR TITLE
Add job definition for running ut of k8s cloud controller manager

### DIFF
--- a/playbooks/openstack-cloud-controller-manager-unit-test/run.yaml
+++ b/playbooks/openstack-cloud-controller-manager-unit-test/run.yaml
@@ -11,9 +11,6 @@
           set -e
           set -x
           source /opt/stack/new/devstack/openrc admin admin
-          openstack server create --flavor 1 --image cirros-0.3.5-x86_64-disk --network private test
-          sleep 5
-          openstack server show test
           add-apt-repository ppa:masterminds/glide -y
           apt-get update -y
           apt-get install glide -y

--- a/playbooks/openstack-cloud-controller-manager-unit-test/run.yaml
+++ b/playbooks/openstack-cloud-controller-manager-unit-test/run.yaml
@@ -10,6 +10,7 @@
         cmd: |
           set -e
           set -x
+          set -o pipefail
           source /opt/stack/new/devstack/openrc admin admin
           add-apt-repository ppa:masterminds/glide -y
           apt-get update -y

--- a/playbooks/openstack-cloud-controller-manager-unit-test/run.yaml
+++ b/playbooks/openstack-cloud-controller-manager-unit-test/run.yaml
@@ -1,0 +1,23 @@
+- hosts: all
+  become: yes
+  roles:
+    - clone-devstack-gate-to-workspace
+    - create-devstack-local-conf
+    - install-devstack
+
+  tasks:
+    - shell:
+        cmd: |
+          set -e
+          set -x
+          source /opt/stack/new/devstack/openrc admin admin
+          openstack server create --flavor 1 --image cirros-0.3.5-x86_64-disk --network private test
+          sleep 5
+          openstack server show test
+          add-apt-repository ppa:masterminds/glide -y
+          apt-get update -y
+          apt-get install glide -y
+          TESTARGS='-v' make test 2>&1 | tee $TEST_RESULTS_TXT
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
+      environment: '{{ golang_env }}'

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -200,3 +200,10 @@
     run: playbooks/terraform-provider-opentelekomcloud-acceptance-test-opentelekomcloud/run.yaml
     secrets:
       - opentelekomcloud_credentials
+
+- job:
+    name: openstack-cloud-controller-manager-unit-test
+    parent: golang-test
+    description: |
+      Run K8S openstack-cloud-controller-manager unit test
+    run: playbooks/openstack-cloud-controller-manager-unit-test/run.yaml


### PR DESCRIPTION
This is the job for the screnario1: running unit tests of the out-tree
k8s cloud controller manager with a devstack envrionment.

Part of #27