### PR TITLE
Enable Octavia in LBaaS test of terraform-openstack-provider

### DIFF
--- a/playbooks/terraform-provider-openstack-acceptance-test-lbaas/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-lbaas/run.yaml
@@ -31,6 +31,7 @@
           echo export OS_FLAVOR_ID=99 >> openrc
           echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
           echo export OS_SHARE_NETWORK_ID=foobar >> openrc
+          echo export OS_USE_OCTAVIA=true >> openrc
           source openrc demo demo
           popd
 


### PR DESCRIPTION
Set environment variable OS_USE_OCTAVIA=true in LBaaS job to make
terraform knowing the deployment is LBaaS + Octavia.

Fixes: #49