### PR TITLE
Modify telefonica job environment variables to fix some issures

### DIFF
--- a/playbooks/terraform-provider-telefonicaopencloud-acceptance-test-telefonica/run.yaml
+++ b/playbooks/terraform-provider-telefonicaopencloud-acceptance-test-telefonica/run.yaml
@@ -21,13 +21,8 @@
           export OS_FLAVOR_ID='c1.medium'
           export OS_POOL_NAME="admin_external_net"
           export OS_EXTGW_ID="$(openstack network show $OS_POOL_NAME -f value -c id)"
-          export OS_IMAGE_NAME="cirros-0.3.5-x86_64-disk"
-          export OS_IMAGE_ID="$(openstack image show $OS_IMAGE_NAME -f value -c id)"
-          if [ -z "$OS_IMAGE_ID" ]; then
-              curl -O http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img
-              export OS_IMAGE_ID="$(openstack image create --file ./cirros-0.3.5-x86_64-disk.img --min-disk 1 --container-format bare --disk-format raw cirros-0.3.5-x86_64-disk -f value -c id)"
-              rm cirros-0.3.5-x86_64-disk.img
-          fi
+          export OS_IMAGE_NAME="Ubuntu 16.04 Server 64bit"
+          export OS_IMAGE_ID=69be1b33-e25c-4a59-9cf4-b307533e4763
           _NET_PREFIX="terraform-provider-telefonicaopencloud"
           export OS_NETWORK_NAME="$_NET_PREFIX-net"
           export OS_NETWORK_ID="$(openstack network show $OS_NETWORK_NAME -f value -c id)"

--- a/playbooks/terraform-provider-telefonicaopencloud-acceptance-test-telefonica/run.yaml
+++ b/playbooks/terraform-provider-telefonicaopencloud-acceptance-test-telefonica/run.yaml
@@ -17,8 +17,8 @@
           export OS_USERNAME="`echo {{ telefonica_credentials.user_name }}`"
 
           export OS_SHARE_NETWORK_ID="foobar"
-          export OS_FLAVOR_ID_RESIZE=2
-          export OS_FLAVOR_ID=1
+          export OS_FLAVOR_ID_RESIZE='c2.medium'
+          export OS_FLAVOR_ID='c1.medium'
           export OS_POOL_NAME="admin_external_net"
           export OS_EXTGW_ID="$(openstack network show $OS_POOL_NAME -f value -c id)"
           export OS_IMAGE_NAME="cirros-0.3.5-x86_64-disk"


### PR DESCRIPTION
1. According to testing, the flavor 1 and flavor 2 cannot be used to create
server in public clouds, we'd better to config to use the c1.medium as the
OS_FLAVOR_ID and c2.medium as the OS_FLAVOR_ID_RESIZE

2. It was proved that volume attaching will fail if we use cirros image for
testing, so we'd better to switch to use an existing Ubuntu image.

For #60 