### PR TITLE
Add unit test and integration test jobs for Misty

### DIFF
--- a/playbooks/misty-integration-test/run.yaml
+++ b/playbooks/misty-integration-test/run.yaml
@@ -1,0 +1,20 @@
+- hosts: all
+  become: yes
+# TODO: the misty will run integration tests against a devstack in next step
+#  roles:
+#    - clone-devstack-gate-to-workspace
+#    - create-devstack-local-conf
+#    - install-devstack
+  tasks:
+    - shell:
+        cmd: |
+          set -e
+          set -o pipefail
+          set -x
+
+          apt-get install ruby ruby-dev -y
+          gem install bundler
+          bundle install
+          rake integration TESTOPTS='-v'
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'

--- a/playbooks/misty-unit-test/run.yaml
+++ b/playbooks/misty-unit-test/run.yaml
@@ -1,0 +1,15 @@
+- hosts: all
+  become: yes
+  tasks:
+    - shell:
+        cmd: |
+          set -e
+          set -o pipefail
+          set -x
+
+          apt-get install ruby ruby-dev -y
+          gem install bundler
+          bundle install
+          rake unit TESTOPTS='-v'
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -209,3 +209,17 @@
       Run Kubernetes openstack-cloud-controller-manager unit test in devstack instance
     run: playbooks/openstack-cloud-controller-manager-unittest/run.yaml
     nodeset: ubuntu-xenial-large
+
+- job:
+    name: misty-unit-test
+    parent: init-test
+    description: |
+      Run unit tests of Misty
+    run: playbooks/misty-unit-test/run.yaml
+
+- job:
+    name: misty-integration-test
+    parent: init-test
+    description: |
+      Run integration tests of Misty
+    run: playbooks/misty-integration-test/run.yaml


### PR DESCRIPTION
This PR added the two jobs for Misty unit tests and integration tests.

For: # flystack/misty/issues/116