### PR TITLE
Novaclient's add_floating_ip function is deprecated use neutron client instead

### DIFF
--- a/playbooks/openstack-cloud-controller-manager-unittest/run.yaml
+++ b/playbooks/openstack-cloud-controller-manager-unittest/run.yaml
@@ -66,7 +66,8 @@
           SECURITY_GROUP_ID=$(openstack port show $PORT_ID -f value -c security_group_ids)
           openstack security group rule create --ingress --protocol tcp --dst-port 22 $SECURITY_GROUP_ID
           FLOATING_IP=$(openstack floating ip create public -f value -c floating_ip_address)
-          openstack server add floating ip $INSTANCE_ID $FLOATING_IP
+          FLOATING_IP_ID=$(openstack floating ip show $FLOATING_IP -f value -c id)
+          neutron floatingip-associate $FLOATING_IP_ID $PORT_ID
 
           if ! is_instance_ssh_accessible ubuntu $FLOATING_IP privatekey_1; then
               echo "Instance(id=$INSTANCE_ID) is still not ssh accessible, exit"


### PR DESCRIPTION
fix #73 