### PR TITLE
Enable pipefail to exit error when test fails

### DIFF
--- a/playbooks/openstack-cloud-controller-manager-unittest/run.yaml
+++ b/playbooks/openstack-cloud-controller-manager-unittest/run.yaml
@@ -9,6 +9,7 @@
         cmd: |
           set -e
           set -x
+          set -o pipefail
 
           # Prepare env on executing node
           source /opt/stack/new/devstack/openrc admin admin


### PR DESCRIPTION
Without this config, the test result will succeed even if it actually has failed test cases.
