### PR TITLE
Disable all q- services

### DIFF
--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -135,6 +135,7 @@
       set -e
       set -x
       cat << EOF >> /tmp/dg-local.conf
+      disable_service q-agt,q-svc,q-dhcp,q-l3,q-meta,q-metering
       enable_service neutron-agent,neutron-api,neutron-dhcp,neutron-l3,neutron-metadata-agent,neutron-metering
       EOF
     executable: /bin/bash


### PR DESCRIPTION
q- services are all still being run even though neutron-
services are being enabled to replace them

Signed-off-by: Melvin Hillsman <mrhillsman@gmail.com>