### PR TITLE
Enable SNAT after devstack installation with neutron-* services

### DIFF
--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -19,6 +19,9 @@
 
       cp devstack-gate/devstack-vm-gate-wrap.sh ./safe-devstack-vm-gate-wrap.sh
       ./safe-devstack-vm-gate-wrap.sh
+
+      eval $(grep FLOATING_RANGE /opt/stack/new/devstack/local.conf)
+      iptables -t nat -A POSTROUTING -s "$FLOATING_RANGE" -o $(ip -4 route | grep ^default | awk '{print $5}') -j MASQUERADE
     executable: /bin/bash
     chdir: '{{ ansible_user_dir }}/workspace'
   environment: '{{ zuul | zuul_legacy_vars }}'


### PR DESCRIPTION
Fix theopenlab/openlab-zuul-jobs#76

When change q-* to neutron-* during devstack installation, SNAT isn't enabled by default which maybe a devstack bug[1], resulting in virtual machine under devstack has no access to the internet, thus could not install package through package management tools, for example apt-get.

This PR adds a rule via iptables to enable SNAT after devstack installation to fix the problem.

[1] https://github.com/openstack-dev/devstack/blob/master/lib/neutron_plugins/services/l3#L135