### PR TITLE
Clean up deprecated job and nodeset define

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -201,15 +201,7 @@
     secrets:
       - opentelekomcloud_credentials
 
-# Kubernetes jobs
-- job:
-    name: openstack-cloud-controller-manager-unittest
-    parent: golang-test
-    description: |
-      Run Kubernetes openstack-cloud-controller-manager unit test in devstack instance
-    run: playbooks/openstack-cloud-controller-manager-unittest/run.yaml
-    nodeset: ubuntu-xenial-large
-
+# OpenLab job self-check jobs
 - job:
     name: openlab-zuul-jobs-check
     parent: init-test
@@ -224,6 +216,16 @@
     vars:
       excluded_path: ""
 
+# Deprecated (Kubernetes nested scenario)
+- job:
+    name: openstack-cloud-controller-manager-unittest
+    parent: golang-test
+    description: |
+      Run Kubernetes openstack-cloud-controller-manager unit test in devstack instance
+    run: playbooks/openstack-cloud-controller-manager-unittest/run.yaml
+    nodeset: ubuntu-xenial-otc
+
+# Kubernetes cloud-provider-openstack jobs
 - job:
     name: cloud-provider-openstack-unittest
     parent: golang-test

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -19,10 +19,10 @@
         label: ubuntu-xenial-ut
 
 - nodeset:
-    name: ubuntu-xenial-large
+    name: ubuntu-xenial-otc
     nodes:
-      - name: ubuntu-xenial-large
-        label: ubuntu-xenial-large
+      - name: ubuntu-xenial-otc
+        label: ubuntu-xenial-otc
 
 - nodeset:
     name: ubuntu-xenial-vexxhost


### PR DESCRIPTION
Some deprecated job and nodeset define should be marked and clean up,
like:

1. openstack-cloud-controller-manager-unittest
2. ubuntu-xenial-large

Closes #106