### PR TITLE
re-use an existing role to avoid creating a new one

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-keystone-authentication-authorization/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-keystone-authentication-authorization/run.yaml
@@ -25,11 +25,6 @@
           export OS_PASSWORD=$(echo '{{ vexxhost_credentials.password }}')
           export OS_REGION_NAME=$(echo '{{ vexxhost_credentials.region_name }}')
 
-          # create administrator role for kubernetes
-          openstack role create k8s-admin
-          # add the k8s-admin role to the admin user
-          openstack role add --user $OS_USERNAME --project $OS_PROJECT_ID k8s-admin
-
           if [[ ! -d "/etc/kubernetes/" ]]; then
               sudo mkdir -p /etc/kubernetes/
           fi
@@ -110,9 +105,13 @@
           # We need the hostname to match the name of the vm started by openstack
           export HOSTNAME_OVERRIDE=$(curl http://169.254.169.254/openstack/latest/meta_data.json | python -c "import sys, json; print json.load(sys.stdin)['name']")
 
-          # copy the same policy json and fix up the project id
+          # copy the same policy json and fix up the hard coded project id
           cp ./examples/webhook/policy.json /etc/kubernetes/
           sed -i -e "s|c1f7910086964990847dc6c8b128f63c|$OS_PROJECT_ID|g" /etc/kubernetes/policy.json
+          # pick an existing role of the user and replace the k8s-admin role in policy.json
+          sed -i -e "s|k8s-admin|creator|g" /etc/kubernetes/policy.json
+          # print the modified file
+          cat /etc/kubernetes/policy.json
 
           pushd ${GOPATH}/src/k8s.io/kubernetes
           export AUTHORIZATION_MODE="Node,Webhook,RBAC"


### PR DESCRIPTION
looks like in vexxhost we don't have privileges to create a role, plus the hassle of cleaning up, so just reuse an existing role