### PR TITLE
[e2e] external cloud controller manager should remove node taint

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -92,8 +92,6 @@
 
           # Sleep to wait for creating serviceaccount default/default complete
           sleep 5
-          # Remove node taint
-          cluster/kubectl.sh taint nodes "$HOSTNAME_OVERRIDE" node.cloudprovider.kubernetes.io/uninitialized-
 
           # Set admin kubeconfig for running e2e tests
           export KUBECONFIG=/var/run/kubernetes/admin.kubeconfig


### PR DESCRIPTION
There's a bunch of things that need to line up for the taint to be
automatically removed by the openstack external cloud controller. We
should have it all lined up now. So let's remove the explicit removal
here. Note that by removing the node taint by hand, we are short
circuiting some of the code in node_controller that is now run inside
the external cloud controller binary. So give that a chance to run:
https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/cloud/node_controller.go#L291