### PR TITLE
[e2e] enable cluster dns for tests to work

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -45,7 +45,7 @@
           export ENABLE_CRI=false
           export ENABLE_HOSTPATH_PROVISIONER=true
           export ENABLE_SINGLE_CA_SIGNER=true
-          export KUBE_ENABLE_CLUSTER_DNS=false
+          export KUBE_ENABLE_CLUSTER_DNS=true
           export LOG_LEVEL=4
           # We want to use the openstack cloud provider
           export CLOUD_PROVIDER=openstack


### PR DESCRIPTION
last 2 failures in e2e tests seem to indicate we need the kube-dns installed and running