### PR TITLE
Support k8s E2E test against specified k8s version

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/post.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/post.yaml
@@ -1,0 +1,14 @@
+- hosts: all
+  become: yes
+  tasks:
+    - name: Upload E2E conformance test result to kubernetes testgrid
+      shell:
+        cmd: |
+          set -e
+          set -x
+          export LOG_DIR='{{ ansible_user_dir }}/workspace/logs/kubernetes'
+          # TODO: Can not find upload_e2e.py in Github kubernetes org
+          # Refer to https://github.com/kubernetes/test-infra/tree/master/testgrid/conformance#using
+          # upload_e2e.py --junit=$LOG_DIR/junit_01.xml --log=$LOG_DIR/e2e.log --bucket=gs://your-bucket
+        executable: /bin/bash
+      environment: '{{ golang_env }}'

--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -98,6 +98,7 @@
           go get -u k8s.io/test-infra/kubetest
           # Build all binaries
           export KUBE_FASTBUILD=true
+          export KUBERNETES_CONFORMANCE_TEST=y
 
           # Run e2e test using local deployment/provider
           kubetest --dump=$LOG_DIR \
@@ -107,7 +108,7 @@
               --provider=local \
               --ginkgo-parallel=1 \
               --test_args="--ginkgo.focus=\\[Conformance\\]" \
-              --timeout=120m
+              --timeout=120m | tee $LOG_DIR/e2e.log
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'
       environment: '{{ golang_env | combine(vexxhost_openrc) }}'

--- a/playbooks/cloud-provider-openstack-acceptance-test/pre.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test/pre.yaml
@@ -1,48 +1,20 @@
-- hosts: all
+- name: build cloud-provider-openstack binary
+  hosts: all
   become: yes
+  roles:
+    - install-k8s
   tasks:
     - shell:
         cmd: |
           set -x
           set -e
 
-          # Install docker
-          apt update -y
-          apt install -y docker.io
-
-          # Custom Docker daemon options via drop-in file then restart
-          mkdir /etc/systemd/system/docker.service.d
-          cat << EOF > /etc/systemd/system/docker.service.d/local-up-cluster.conf
-          [Service]
-          Environment="DOCKER_OPTS=--iptables=false"
-          EOF
-          systemctl daemon-reload
-          systemctl restart docker
-
-          # Install etcd
-          wget https://github.com/coreos/etcd/releases/download/v3.3.0/etcd-v3.3.0-linux-amd64.tar.gz
-          tar -zxf etcd-v3.3.0-linux-amd64.tar.gz
-          cp etcd-v3.3.0-linux-amd64/etcd{,ctl} /usr/local/bin/
-
           # Install dependencies
           go get -u github.com/Masterminds/glide
 
-          # Build binaries
+          # Build cloud-provider-openstack binaries
           make build
-          # Build k8s cmd
-          git clone https://github.com/kubernetes/kubernetes ${GOPATH}/src/k8s.io/kubernetes
-          make -C ${GOPATH}/src/k8s.io/kubernetes WHAT="cmd/kubectl cmd/hyperkube"
 
-          # Stopping firewall and allow all traffic
-          iptables -F
-          iptables -X
-          iptables -t nat -F
-          iptables -t nat -X
-          iptables -t mangle -F
-          iptables -t mangle -X
-          iptables -P INPUT ACCEPT
-          iptables -P FORWARD ACCEPT
-          iptables -P OUTPUT ACCEPT
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'
       environment: '{{ golang_env }}'

--- a/roles/copy-files-on-node/tasks/main.yml
+++ b/roles/copy-files-on-node/tasks/main.yml
@@ -23,3 +23,4 @@
       - --include=*/
       - --exclude=*
       - --prune-empty-dirs
+      - --min-size=1

--- a/roles/install-k8s-jobs-dependences/tasks/main.yaml
+++ b/roles/install-k8s-jobs-dependences/tasks/main.yaml
@@ -1,4 +1,4 @@
-- name: Install K8S jobs dependences
+- name: Install K8S jobs dependences (#Deprecated)
   shell:
     cmd: |
       set -e

--- a/roles/install-k8s/defaults/main.yaml
+++ b/roles/install-k8s/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+k8s_version: 'master'
+etcd_version: 'v3.3.0'

--- a/roles/install-k8s/tasks/main.yaml
+++ b/roles/install-k8s/tasks/main.yaml
@@ -1,0 +1,42 @@
+- name: install docker, kubernetes {{ k8s_version }} and etcd {{ etcd_version }}, disable iptables
+  shell:
+    cmd: |
+      set -x
+      set -e
+
+      # Install docker
+      apt update -y
+      apt install -y docker.io
+
+      # Custom Docker daemon options via drop-in file then restart
+      mkdir /etc/systemd/system/docker.service.d
+      cat << EOF > /etc/systemd/system/docker.service.d/local-up-cluster.conf
+      [Service]
+      Environment="DOCKER_OPTS=--iptables=false"
+      EOF
+      systemctl daemon-reload
+      systemctl restart docker
+
+      # Install etcd
+      wget https://github.com/coreos/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-amd64.tar.gz
+      tar -zxf etcd-{{ etcd_version }}-linux-amd64.tar.gz
+      cp etcd-{{ etcd_version }}-linux-amd64/etcd{,ctl} /usr/local/bin/
+
+      # Build k8s cmd
+      git clone https://github.com/kubernetes/kubernetes ${GOPATH}/src/k8s.io/kubernetes -b '{{ k8s_version }}'
+      make -C ${GOPATH}/src/k8s.io/kubernetes WHAT="cmd/kubectl cmd/hyperkube"
+
+      # Stopping firewall and allow all traffic
+      iptables -F
+      iptables -X
+      iptables -t nat -F
+      iptables -t nat -X
+      iptables -t mangle -F
+      iptables -t mangle -X
+      iptables -P INPUT ACCEPT
+      iptables -P FORWARD ACCEPT
+      iptables -P OUTPUT ACCEPT
+
+    executable: /bin/bash
+    chdir: '{{ zuul.project.src_dir }}'
+  environment: '{{ golang_env }}'

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -274,10 +274,18 @@
     name: cloud-provider-openstack-acceptance-test-e2e-conformance
     parent: cloud-provider-openstack-acceptance-test
     description: |
-      Run Kubernetes Conformance tests
+      Run Kubernetes E2E Conformance tests against Kubernetes master
     run: playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
     secrets:
       - vexxhost_credentials
+
+- job:
+    name: cloud-provider-openstack-acceptance-test-e2e-conformance-latest-release
+    parent: cloud-provider-openstack-acceptance-test-e2e-conformance
+    description: |
+      Run Kubernetes E2E Conformance tests against Kubernetes latest release
+    vars:
+      k8s_version: 'v1.10.0'
 
 - job:
     name: cloud-provider-openstack-acceptance-test-standalone-cinder

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -276,6 +276,7 @@
     description: |
       Run Kubernetes E2E Conformance tests against Kubernetes master
     run: playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+    post-run: playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/post.yaml
     secrets:
       - vexxhost_credentials
 


### PR DESCRIPTION
- Create install-k8s role
- Support to specify version of k8s and etcd
- Add new job
cloud-provider-openstack-acceptance-test-e2e-conformance-latest-release
- Skip to copy 0 size test_results.html
- Add placeholder to upload E2E result to testgrid

Partial-Bug: kubernetes/cloud-provider-openstack#103