### PR TITLE
Use public external network for external LB scenario

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
@@ -25,7 +25,7 @@
           username = $OS_USERNAME
           region = $OS_REGION_NAME
           [LoadBalancer]
-          floating-network-id = $(openstack network list --external -f value -c ID | head -n 1)
+          floating-network-id = $(openstack network list --external -f value -c ID | grep public | head -n 1)
           subnet-id = $(openstack network list --internal -f value -c Subnets | head -n 1)
           [BlockStorage]
           bs-version = v2


### PR DESCRIPTION
"openstack network list" returns 2 networks in vexxhost, use the one with name `public`