### PR TITLE
Change k8s e2e job v1.10.0 to v1.10

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -281,10 +281,10 @@
       - vexxhost_credentials
 
 - job:
-    name: cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.10.0
+    name: cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.10
     parent: cloud-provider-openstack-acceptance-test-e2e-conformance
     description: |
-      Run Kubernetes E2E Conformance tests against Kubernetes v1.10.0
+      Run Kubernetes E2E Conformance tests against Kubernetes v1.10
     vars:
       k8s_version: 'v1.10.0'
 


### PR DESCRIPTION
In Kubernetes/OpenStack integration scenario, we should keep pipeline
name, job name and trigger comment consistence, that build consist user
experience for developer from k8s community, and easy to understand how
to trigger the specific jobs when the job failed.

- branch-v1.10.0 should be just branch-v1.10

Partial-Bug: theopenlab/openlab#46