### PR TITLE
Support enabling Zun on devstack

### DIFF
--- a/playbooks/gophercloud-acceptance-test/run.yaml
+++ b/playbooks/gophercloud-acceptance-test/run.yaml
@@ -6,6 +6,7 @@
       enable_services:
         - 'manila'
         - 'designate'
+        - 'zun'
     - install-devstack
   tasks:
     - shell:

--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -130,3 +130,22 @@
   environment: '{{ zuul | zuul_legacy_vars }}'
   when:
     - '"fwaas-v2" in enable_services'
+
+- name: create devstack local conf with zun enabled
+  shell:
+    cmd: |
+      set -e
+      set -x
+      cat << EOF >> /tmp/dg-local.conf
+      enable_service zun-api,zun-compute,zun-wsproxy
+      enable_plugin devstack-plugin-container https://git.openstack.org/openstack/devstack-plugin-container
+      KURYR_CAPABILITY_SCOPE=global
+      KURYR_ETCD_PORT=2379
+      enable_plugin kuryr-libnetwork https://git.openstack.org/openstack/kuryr-libnetwork
+      enable_plugin zun https://git.openstack.org/openstack/zun
+      EOF
+    executable: /bin/bash
+    chdir: '{{ ansible_user_dir }}/workspace'
+  environment: '{{ zuul | zuul_legacy_vars }}'
+  when:
+    - '"zun" in enable_services'

--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -16,6 +16,9 @@
       export PROJECTS="openstack/designate $PROJECTS"
       export PROJECTS="openstack/python-manilaclient openstack/manila-tempest-plugin $PROJECTS"
       export PROJECTS="openstack/barbican openstack/python-barbicanclient $PROJECTS"
+      export PROJECTS="openstack/devstack-plugin-container $PROJECTS"
+      export PROJECTS="openstack/kuryr-libnetwork $PROJECTS"
+      export PROJECTS="openstack/zun $PROJECTS"
 
       cp devstack-gate/devstack-vm-gate-wrap.sh ./safe-devstack-vm-gate-wrap.sh
       ./safe-devstack-vm-gate-wrap.sh


### PR DESCRIPTION
Gophercloud will add support for OpenStack Zun and it is using
OpenLab for testing. Therefore, we need to enable Zun in
devstack jobs. The original request comes from this PR:

  https://github.com/gophercloud/gophercloud/pull/858