### PR TITLE
Extract openrc as roles to avoid security risk

### DIFF
--- a/playbooks/gophercloud-acceptance-test-telefonica/run.yaml
+++ b/playbooks/gophercloud-acceptance-test-telefonica/run.yaml
@@ -1,20 +1,12 @@
 - hosts: all
   become: yes
+  roles:
+    - export-telefonica-openrc
   tasks:
     - shell:
         cmd: |
           apt-get install python-pip -y
           pip install -U python-openstackclient
-          # NOTE: the following commands may include sensitive information please do not print in job logs
-          export OS_PASSWORD="`echo {{ telefonica_credentials.password }}`"
-          export OS_AUTH_TYPE="`echo {{ telefonica_credentials.auth_type }}`"
-          export OS_AUTH_URL="`echo {{ telefonica_credentials.auth_url }}`"
-          export OS_IDENTITY_API_VERSION="`echo {{ telefonica_credentials.identity_api_version }}`"
-          export OS_DOMAIN_NAME="`echo {{ telefonica_credentials.domain_name }}`"
-          export OS_PROJECT_NAME="`echo {{ telefonica_credentials.project_name}}`"
-          export OS_REGION_NAME="`echo {{ telefonica_credentials.region_name}}`"
-          export OS_TENANT_NAME="`echo {{ telefonica_credentials.project_name }}`"
-          export OS_USERNAME="`echo {{ telefonica_credentials.user_name }}`"
 
           export OS_SHARE_NETWORK_ID="foobar"
           export OS_FLAVOR_ID_RESIZE=2
@@ -65,4 +57,4 @@
           } 2>&1 | tee $TEST_RESULTS_TXTT
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'
-      environment: '{{ golang_env }}'
+      environment: '{{ golang_env | combine(telefonica_openrc) }}'

--- a/playbooks/terraform-provider-flexibleengine-acceptance-test-orange/run.yaml
+++ b/playbooks/terraform-provider-flexibleengine-acceptance-test-orange/run.yaml
@@ -1,23 +1,12 @@
 - hosts: all
   become: yes
+  roles:
+    - export-orange-openrc
   tasks:
     - shell:
         cmd: |
           apt-get install python-pip -y
           pip install -U python-openstackclient
-          # NOTE: the following commands may include sensitive information please do not print in job logs
-          export OS_PASSWORD="`echo {{ orange_credentials.password }}`"
-          export OS_AUTH_TYPE="`echo {{ orange_credentials.auth_type }}`"
-          export OS_AUTH_URL="`echo {{ orange_credentials.auth_url }}`"
-          export OS_IDENTITY_API_VERSION="`echo {{ orange_credentials.identity_api_version }}`"
-          export OS_DOMAIN_NAME="`echo {{ orange_credentials.domain_name }}`"
-          export OS_PROJECT_NAME="`echo {{ orange_credentials.project_name}}`"
-          export OS_REGION_NAME="`echo {{ orange_credentials.region_name}}`"
-          export OS_TENANT_NAME="`echo {{ orange_credentials.project_name }}`"
-          export OS_USERNAME="`echo {{ orange_credentials.user_name }}`"
-          export OS_ACCESS_KEY="`echo {{ orange_credentials.access_key }}`"
-          export OS_SECRET_KEY="`echo {{ orange_credentials.secret_key }}`"
-          export OS_AVAILABILITY_ZONE="`echo {{ orange_credentials.availability_zone }}`"
 
           export OS_SHARE_NETWORK_ID="foobar"
           export OS_FLAVOR_ID_RESIZE="t2.small"
@@ -61,4 +50,4 @@
           make testacc 2>&1 | tee $TEST_RESULTS_TXT
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'
-      environment: '{{ golang_env }}'
+      environment: '{{ golang_env | combine(orange_openrc) }}'

--- a/playbooks/terraform-provider-opentelekomcloud-acceptance-test-opentelekomcloud/run.yaml
+++ b/playbooks/terraform-provider-opentelekomcloud-acceptance-test-opentelekomcloud/run.yaml
@@ -1,23 +1,12 @@
 - hosts: all
   become: yes
+  roles:
+    - export-opentelekomcloud-openrc
   tasks:
     - shell:
         cmd: |
           apt-get install python-pip -y
           pip install -U python-openstackclient
-          # NOTE: the following commands may include sensitive information please do not print in job logs
-          export OS_PASSWORD="`echo {{ opentelekomcloud_credentials.password }}`"
-          export OS_AUTH_TYPE="`echo {{ opentelekomcloud_credentials.auth_type }}`"
-          export OS_AUTH_URL="`echo {{ opentelekomcloud_credentials.auth_url }}`"
-          export OS_IDENTITY_API_VERSION="`echo {{ opentelekomcloud_credentials.identity_api_version }}`"
-          export OS_DOMAIN_NAME="`echo {{ opentelekomcloud_credentials.domain_name }}`"
-          export OS_PROJECT_NAME="`echo {{ opentelekomcloud_credentials.project_name}}`"
-          export OS_REGION_NAME="`echo {{ opentelekomcloud_credentials.region_name}}`"
-          export OS_TENANT_NAME="`echo {{ opentelekomcloud_credentials.project_name }}`"
-          export OS_USERNAME="`echo {{ opentelekomcloud_credentials.user_name }}`"
-          export OS_ACCESS_KEY="`echo {{ opentelekomcloud_credentials.access_key }}`"
-          export OS_SECRET_KEY="`echo {{ opentelekomcloud_credentials.secret_key }}`"
-          export OS_AVAILABILITY_ZONE="`echo {{ opentelekomcloud_credentials.availability_zone }}`"
 
           set -o pipefail
           set -x
@@ -49,4 +38,4 @@
 
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'
-      environment: '{{ golang_env }}'
+      environment: '{{ golang_env | combine(opentelekomcloud_openrc) }}'

--- a/playbooks/terraform-provider-telefonicaopencloud-acceptance-test-telefonica/run.yaml
+++ b/playbooks/terraform-provider-telefonicaopencloud-acceptance-test-telefonica/run.yaml
@@ -1,20 +1,12 @@
 - hosts: all
   become: yes
+  roles:
+    - export-telefonica-openrc
   tasks:
     - shell:
         cmd: |
           apt-get install python-pip -y
           pip install -U python-openstackclient
-          # NOTE: the following commands may include sensitive information please do not print in job logs
-          export OS_PASSWORD="`echo {{ telefonica_credentials.password }}`"
-          export OS_AUTH_TYPE="`echo {{ telefonica_credentials.auth_type }}`"
-          export OS_AUTH_URL="`echo {{ telefonica_credentials.auth_url }}`"
-          export OS_IDENTITY_API_VERSION="`echo {{ telefonica_credentials.identity_api_version }}`"
-          export OS_DOMAIN_NAME="`echo {{ telefonica_credentials.domain_name }}`"
-          export OS_PROJECT_NAME="`echo {{ telefonica_credentials.project_name}}`"
-          export OS_REGION_NAME="`echo {{ telefonica_credentials.region_name}}`"
-          export OS_TENANT_NAME="`echo {{ telefonica_credentials.project_name }}`"
-          export OS_USERNAME="`echo {{ telefonica_credentials.user_name }}`"
 
           export OS_SHARE_NETWORK_ID="foobar"
           export OS_FLAVOR_ID_RESIZE='c2.medium'
@@ -59,4 +51,4 @@
 
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'
-      environment: '{{ golang_env }}'
+      environment: '{{ golang_env | combine(telefonica_openrc) }}'

--- a/roles/export-opentelekomcloud-openrc/tasks/main.yaml
+++ b/roles/export-opentelekomcloud-openrc/tasks/main.yaml
@@ -1,0 +1,16 @@
+- name: Set fact for opentelekomcloud openrc
+  set_fact:
+    opentelekomcloud_openrc:
+      OS_PASSWORD: '{{ opentelekomcloud_credentials.password }}'
+      OS_AUTH_TYPE: '{{ opentelekomcloud_credentials.auth_type }}'
+      OS_AUTH_URL: '{{ opentelekomcloud_credentials.auth_url }}'
+      OS_IDENTITY_API_VERSION: '{{ opentelekomcloud_credentials.identity_api_version }}'
+      OS_DOMAIN_NAME: '{{ opentelekomcloud_credentials.domain_name }}'
+      OS_PROJECT_NAME: '{{ opentelekomcloud_credentials.project_name}}'
+      OS_REGION_NAME: '{{ opentelekomcloud_credentials.region_name}}'
+      OS_TENANT_NAME: '{{ opentelekomcloud_credentials.project_name }}'
+      OS_USERNAME: '{{ opentelekomcloud_credentials.user_name }}'
+      OS_ACCESS_KEY: '{{ opentelekomcloud_credentials.access_key }}'
+      OS_SECRET_KEY: '{{ opentelekomcloud_credentials.secret_key }}'
+      OS_AVAILABILITY_ZONE: '{{ opentelekomcloud_credentials.availability_zone }}'
+  no_log: yes

--- a/roles/export-orange-openrc/tasks/main.yaml
+++ b/roles/export-orange-openrc/tasks/main.yaml
@@ -1,0 +1,16 @@
+- name: Set fact for orange openrc
+  set_fact:
+    orange_openrc:
+      OS_PASSWORD: '{{ orange_credentials.password }}'
+      OS_AUTH_TYPE: '{{ orange_credentials.auth_type }}'
+      OS_AUTH_URL: '{{ orange_credentials.auth_url }}'
+      OS_IDENTITY_API_VERSION: '{{ orange_credentials.identity_api_version }}'
+      OS_DOMAIN_NAME: '{{ orange_credentials.domain_name }}'
+      OS_PROJECT_NAME: '{{ orange_credentials.project_name}}'
+      OS_REGION_NAME: '{{ orange_credentials.region_name}}'
+      OS_TENANT_NAME: '{{ orange_credentials.project_name }}'
+      OS_USERNAME: '{{ orange_credentials.user_name }}'
+      OS_ACCESS_KEY: '{{ orange_credentials.access_key }}'
+      OS_SECRET_KEY: '{{ orange_credentials.secret_key }}'
+      OS_AVAILABILITY_ZONE: '{{ orange_credentials.availability_zone }}'
+  no_log: yes

--- a/roles/export-telefonica-openrc/tasks/main.yaml
+++ b/roles/export-telefonica-openrc/tasks/main.yaml
@@ -1,0 +1,13 @@
+- name: Set fact for telefonica openrc
+  set_fact:
+    telefonica_openrc:
+      OS_PASSWORD: '{{ telefonica_credentials.password }}'
+      OS_AUTH_TYPE: '{{ telefonica_credentials.auth_type }}'
+      OS_AUTH_URL: '{{ telefonica_credentials.auth_url }}'
+      OS_IDENTITY_API_VERSION: '{{ telefonica_credentials.identity_api_version }}'
+      OS_DOMAIN_NAME: '{{ telefonica_credentials.domain_name }}'
+      OS_PROJECT_NAME: '{{ telefonica_credentials.project_name}}'
+      OS_REGION_NAME: '{{ telefonica_credentials.region_name}}'
+      OS_TENANT_NAME: '{{ telefonica_credentials.project_name }}'
+      OS_USERNAME: '{{ telefonica_credentials.user_name }}'
+  no_log: yes

--- a/roles/export-vexxhost-openrc/tasks/main.yaml
+++ b/roles/export-vexxhost-openrc/tasks/main.yaml
@@ -14,3 +14,4 @@
       OS_PASSWORD: '{{ vexxhost_credentials.password }}'
       OS_REGION_NAME: '{{ vexxhost_credentials.region_name }}'
       OS_DOMAIN_NAME: '{{ vexxhost_credentials.user_domain_name }}'
+  no_log: yes

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -83,14 +83,6 @@
       os_branch: 'stable/mitaka'
     nodeset: ubuntu-trusty
 
-# Gophercloud acceptance tests with Telefonica cloud
-- job:
-    name: gophercloud-acceptance-test-telefonica
-    parent: golang-test
-    description: |
-      Run gophercloud acceptance test against telefonica cloud
-    run: playbooks/gophercloud-acceptance-test-telefonica/run.yaml
-
 # Terraform-provider-openstack jobs
 - job:
     name: terraform-provider-openstack-unittest

--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -2,6 +2,7 @@
 # "encrypt_secret.py" in zuul/tools/, following is a example to encrypt the username
 # echo "your_username" | ./encrypt_secret.py http://zuul-web-ip:9000/openlab theopenlab/openlab-zuul-jobs
 
+# TODO: Deprecated for now, need to update when get new dedicated account
 - secret:
     name: telefonica_credentials
     data:
@@ -74,6 +75,7 @@
           Xeke6lnQ54oBN+3iNByArBOm2bL3uSKQyRy97uVNr+2PQCp3vd0Ic2T6N2cTUwctm2GSs
           dN5OaheYYKStUoqR2vCxADvB5tssTR+4AA7JB8K22apmNb/XA4Zzaqx1L1wJNw=
 
+# TODO: Deprecated for now, need to update when get new dedicated account
 - secret:
     name: orange_credentials
     data:
@@ -179,6 +181,7 @@
           ZE9YnBJH0U/0FchGt4P1X1UXgTlGEOxa2FRYjHyfgyK02vuhtKE/4biruqHveEPnw7Rpy
           ubs4p1hw7nTIgFtNCAt8AhxT1FK8lgmgyyc14qiJJCZ02S9U0b1x10zjw5lwpo=
 
+# TODO: Deprecated for now, need to update when get new dedicated account
 - secret:
     name: opentelekomcloud_credentials
     data:


### PR DESCRIPTION
Closes #115 
- extract openrc as roles to avoid security risk
- delete duplicated job definition gophercloud-acceptance-test-telefonica