### PR TITLE
Use FAILURE to replace RETRY_LIMIT when compile error happen

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
@@ -11,6 +11,9 @@
           set -e
           set -o pipefail
 
+          # Build cloud-provider-openstack binaries
+          make build
+
           # Create cloud-config
           mkdir -p /etc/kubernetes/
           cat << EOF >> /etc/kubernetes/cloud-config

--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -10,6 +10,9 @@
           set -e
           set -o pipefail
 
+          # Build cloud-provider-openstack binaries
+          make build
+
           # Create cloud-config
           mkdir -p /etc/kubernetes/
           cat << EOF >> /etc/kubernetes/cloud-config

--- a/playbooks/cloud-provider-openstack-acceptance-test-k8s-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-k8s-cinder/run.yaml
@@ -9,6 +9,9 @@
           set -e
           set -o pipefail
 
+          # Build cloud-provider-openstack binaries
+          make build
+
           # Create cloud-config
           mkdir -p /etc/kubernetes/
           cat << EOF >> /etc/kubernetes/cloud-config

--- a/playbooks/cloud-provider-openstack-acceptance-test-keystone-authentication-authorization/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-keystone-authentication-authorization/run.yaml
@@ -11,6 +11,9 @@
           set -e
           set -o pipefail
 
+          # Build cloud-provider-openstack binaries
+          make build
+
           apt-get install python-pip -y
           pip install -U python-openstackclient
 

--- a/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
@@ -11,6 +11,9 @@
           set -e
           set -o pipefail
 
+          # Build cloud-provider-openstack binaries
+          make build
+
           apt-get install python-pip -y
           pip install -U python-openstackclient python-octaviaclient python-neutronclient
 

--- a/playbooks/cloud-provider-openstack-acceptance-test-standalone-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-standalone-cinder/run.yaml
@@ -13,6 +13,9 @@
           set -e
           set -o pipefail
 
+          # Build cloud-provider-openstack binaries
+          make build
+
           # Create cloud-config
           source /opt/stack/new/devstack/openrc admin admin
           mkdir -p /etc/kubernetes/

--- a/playbooks/cloud-provider-openstack-acceptance-test/pre.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test/pre.yaml
@@ -1,4 +1,4 @@
-- name: build cloud-provider-openstack binary
+- name: Install dependencies
   hosts: all
   become: yes
   roles:
@@ -11,9 +11,6 @@
 
           # Install dependencies
           go get -u github.com/Masterminds/glide
-
-          # Build cloud-provider-openstack binaries
-          make build
 
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'


### PR DESCRIPTION
Currently we execute make build in pre.yaml of k8s integration jobs to
compile code, but if compile error happen, that cause job test result
fall into RETRY_LIMIT status, that make some confusion, we should move
make build into run.yaml to cause exact FAILURE status.

Closes #151