### PR TITLE
Enable Octavia in gophercloud jobs

### DIFF
--- a/playbooks/gophercloud-acceptance-test/run.yaml
+++ b/playbooks/gophercloud-acceptance-test/run.yaml
@@ -7,6 +7,7 @@
         - 'manila'
         - 'designate'
         - 'zun'
+        - 'lbaas'
     - install-devstack
   tasks:
     - name: Run acceptance tests with gophercloud
@@ -49,6 +50,7 @@
               go test -v -tags "fixtures acceptance" ./acceptance/openstack/networking/v2/
               go test -v -tags "fixtures acceptance" ./acceptance/openstack/blockstorage/v2/
               go test -v -tags "fixtures acceptance" -run "SecGroup|Flavor" ./acceptance/openstack/compute/v2/
+              go test -v -tags "fixtures acceptance" ./acceptance/openstack/loadbalancer/v2/
               # To enable more after the fix of https://github.com/gophercloud/gophercloud/issues/608
               # go test -v -tags "fixtures acceptance" ./acceptance/openstack/imageservice/v2/
               # go test -v -tags "fixtures acceptance" ./acceptance/openstack/identity/v2/

--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -19,6 +19,10 @@
       export PROJECTS="openstack/devstack-plugin-container $PROJECTS"
       export PROJECTS="openstack/kuryr-libnetwork $PROJECTS"
       export PROJECTS="openstack/zun openstack/zun-tempest-plugin $PROJECTS"
+      export PROJECTS="openstack/diskimage-builder $PROJECTS"
+      export PROJECTS="openstack/tripleo-image-elements $PROJECTS"
+      export PROJECTS="openstack/neutron-lbaas $PROJECTS"
+      export PROJECTS="openstack/octavia python-octaviaclient $PROJECTS"
 
       cp devstack-gate/devstack-vm-gate-wrap.sh ./safe-devstack-vm-gate-wrap.sh
       ./safe-devstack-vm-gate-wrap.sh


### PR DESCRIPTION
Gophercloud supports Octavia and it is using OpenLab for testing.
Therefore, we need to enable Octavia in devstack jobs.

https://github.com/theopenlab/openlab-zuul-jobs/issues/143