### PR TITLE
Make ansible-lint check mandatory and enable "all tasks named" rule

### DIFF
--- a/playbooks/openlab-zuul-jobs-check/run.yaml
+++ b/playbooks/openlab-zuul-jobs-check/run.yaml
@@ -7,7 +7,7 @@
           set -o pipefail
           set -x
           pip install ansible-lint
-          find playbooks -type f -regex '.*.y[a]?ml' -not -path "{{ excluded_path }}" -print0 | xargs -t -n1 -0 ansible-lint -xANSIBLE0012 || true
+          find playbooks -type f -regex '.*.y[a]?ml' -not -path "{{ excluded_path }}" -print0 | xargs -t -n1 -0 ansible-lint -xANSIBLE0012,ANSIBLE0013,ANSIBLE0006
           find playbooks -type f -regex '.*.y[a]?ml' -not -path "{{ excluded_path }}" -exec ansible-playbook -v --syntax-check -i ./playbooks/openlab-zuul-jobs-check/inventory \{\} + > /dev/null
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'


### PR DESCRIPTION
This change skip following lint rules for now:

ANSIBLE0006: Using command rather than module
ANSIBLE0012: Commands should not change things if nothing needs doing
ANSIBLE0013: Use shell only when shell functionality is required

Closes #164