### PR TITLE
Revert changes from b4b95293554f639faed4cc1a4a48da0f9efa240f

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/post.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/post.yaml
@@ -8,7 +8,7 @@
           set -x
           cd ${GOPATH}/src/k8s.io/kubernetes
           cluster/kubectl.sh config use-context local
-          cluster/kubectl.sh delete -f '{{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack/examples/cinder-csi-plugin/nginx.yaml'
-          cluster/kubectl.sh delete -f '{{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack/manifests/cinder-csi-plugin'
+          cluster/kubectl.sh delete -f '{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/examples/cinder-csi-plugin/nginx.yaml'
+          cluster/kubectl.sh delete -f '{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/manifests/cinder-csi-plugin'
         executable: /bin/bash
       environment: '{{ golang_env }}'

--- a/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
@@ -156,4 +156,5 @@
               exit 1
           fi
         executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
       environment: '{{ golang_env | combine(vexxhost_openrc) }}'

--- a/playbooks/cloud-provider-openstack-acceptance-test/pre.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test/pre.yaml
@@ -3,18 +3,6 @@
   roles:
     - install-k8s
   tasks:
-    - name: rsync cloud-provider-openstack to k8s.io
-      shell:
-        cmd: |
-          set -x
-          set -e
-          set -o pipefail
-          
-          mkdir -p k8s.io
-          rsync -avz --progress src/github.com/kubernetes/ src/k8s.io/
-        executable: /bin/bash
-      environment: '{{ golang_env | combine(vexxhost_openrc) }}'
-
     - name: Install dependencies for cloud-provider-openstack acceptance test
       shell:
         cmd: |
@@ -22,7 +10,8 @@
           set -e
 
           # Install dependencies
-          cd src/k8s.io/cloud-provider-openstack
           go get -u github.com/Masterminds/glide
+
         executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
       environment: '{{ golang_env }}'

--- a/playbooks/cloud-provider-openstack-unittest/run.yaml
+++ b/playbooks/cloud-provider-openstack-unittest/run.yaml
@@ -3,18 +3,6 @@
   roles:
     - export-vexxhost-openrc
   tasks:
-    - name: Copy all github.com/project to k8s.io
-      shell:
-        cmd: |
-          set -x
-          set -e
-          set -o pipefail
-          
-          mkdir -p k8s.io
-          rsync -avz --progress src/github.com/kubernetes/ src/k8s.io/
-        executable: /bin/bash
-      environment: '{{ golang_env | combine(vexxhost_openrc) }}'
-
     - name: Run unit tests with cloud-provider-openstack
       shell:
         cmd: |
@@ -23,7 +11,7 @@
           set -o pipefail
 
           go get -u github.com/Masterminds/glide
-          cd src/k8s.io/cloud-provider-openstack
           TESTARGS='-v' make test 2>&1 | tee $TEST_RESULTS_TXT
         executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
       environment: '{{ golang_env | combine(vexxhost_openrc) }}'


### PR DESCRIPTION
Because this changes have been directly pushed to theopenlab/openlab-zuul-jobs. and after checking with PR https://github.com/kubernetes/cloud-provider-openstack/pull/137 by triggering a job, these changes have broken the k8s+openstack jobs.
FYI: http://logs.openlabtesting.org/logs/37/137/e3f16bd76599a973dfedc45f909841901f85828b/cloud-provider-openstack-acceptance-test-standalone-cinder/cloud-provider-openstack-acceptance-test-standalone-cinder/af37529/