### PR TITLE
Change cinder standalone jobs to use general ubuntu-xenial node

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -287,6 +287,7 @@
       Run cinder standalone acceptance tests of cloud-provider-openstack
     run: playbooks/cloud-provider-openstack-acceptance-test-standalone-cinder/run.yaml
     post-run: playbooks/cloud-provider-openstack-acceptance-test-standalone-cinder/post.yaml
+    nodeset: ubuntu-xenial
 
 - job:
     name: cloud-provider-openstack-acceptance-test-csi-cinder


### PR DESCRIPTION
This change can save the ubuntu-xenial-vexxhost node consumption.