### PR TITLE
Change k8s ut job back to use vexxhost nodes

### DIFF
--- a/playbooks/cloud-provider-openstack-unittest/run.yaml
+++ b/playbooks/cloud-provider-openstack-unittest/run.yaml
@@ -1,7 +1,7 @@
 - hosts: all
   become: yes
   roles:
-    - export-opentelekomcloud-openrc
+    - export-vexxhost-openrc
   tasks:
     - name: Run unit tests with cloud-provider-openstack
       shell:
@@ -14,4 +14,4 @@
           TESTARGS='-v' make test 2>&1 | tee $TEST_RESULTS_TXT
         executable: /bin/bash
         chdir: '{{ k8s_specific_src_dir }}'
-      environment: '{{ golang_env | combine(opentelekomcloud_openrc) }}'
+      environment: '{{ golang_env | combine(vexxhost_openrc) }}'

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -251,8 +251,7 @@
       Run unit test of cloud-provider-openstack
     run: playbooks/cloud-provider-openstack-unittest/run.yaml
     secrets:
-      - opentelekomcloud_credentials
-    nodeset: ubuntu-xenial-otc
+      - vexxhost_credentials
 
 - job:
     name: cloud-provider-openstack-acceptance-test


### PR DESCRIPTION
Seems it is unstable to run k8s unit tests job on OTC cloud.