### PR TITLE
Don't need to create customized local conf when running cinder standalone job

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-standalone-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-standalone-cinder/run.yaml
@@ -2,7 +2,6 @@
   become: yes
   roles:
     - clone-devstack-gate-to-workspace
-    - create-devstack-local-conf
     - role: install-devstack
       environment:
         OVERRIDE_ENABLED_SERVICES: 'key,c-sch,c-api,c-vol,rabbit,mysql'


### PR DESCRIPTION
Don't need to change any devstack options with customer local conf and
that will always enable neutron which we do not need in this job.
See: http://logs.openlabtesting.org/logs/33/133/cc2d3456b2bdedda93bc54ffd3e79cd1fe3167cf/cloud-provider-openstack-acceptance-test-standalone-cinder/cloud-provider-openstack-acceptance-test-standalone-cinder/b152670/logs/