### PR TITLE
Disable neutron-lbaas plugin

### DIFF
--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -90,7 +90,6 @@
       set -x
       cat << EOF >> /tmp/dg-local.conf
       enable_service octavia,o-cw,o-hm,o-hk,o-api
-      enable_plugin neutron-lbaas https://git.openstack.org/openstack/neutron-lbaas
       enable_plugin octavia https://git.openstack.org/openstack/octavia
       enable_plugin barbican https://git.openstack.org/openstack/barbican
       EOF


### PR DESCRIPTION
Gophercloud job broke on running db migration on neutron-lbaas [1].
However, neutron-lbaas is deprecated so simply removing it should
be fine.

[1] http://logs.openlabtesting.org/logs/27/927/70f04e44e91c14b867c5ead4b8e859b57864213e/check/gophercloud-acceptance-test/8ab8306/