### PR TITLE
Bump the default golang version to 1.10.2

### DIFF
--- a/roles/install-golang/defaults/main.yml
+++ b/roles/install-golang/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-go_version: '1.10.1'
+go_version: '1.10.2'
 go_tarball: 'go{{ go_version }}.linux-amd64.tar.gz'
 go_download_location: 'https://storage.googleapis.com/golang/{{ go_tarball }}'


### PR DESCRIPTION
See: http://logs.openlabtesting.org/logs/periodic/github.com/kubernetes/cloud-provider-openstack/master/cloud-provider-openstack-acceptance-test-e2e-conformance/8c9c326/

The Kubernetes need golang version 1.10.2 or greater