### PR TITLE
Move the pipelines and base job to openlab-zuul-jobs repo

### DIFF
--- a/playbooks/base/post-logs.yaml
+++ b/playbooks/base/post-logs.yaml
@@ -1,0 +1,13 @@
+- hosts: localhost
+  roles:
+    - role: add-fileserver
+      fileserver: "{{ site_logs }}"
+    - ara-report
+
+- hosts: "{{ site_logs.fqdn }}"
+  gather_facts: False
+  roles:
+    - role: upload-logs
+      # NOTE: because we use same host for zuul status and logs server, added
+      # a '/logs' suffix for the convenience to routing request
+      zuul_log_url: "http://logs.openlabtesting.org/logs"

--- a/playbooks/base/post-ssh.yaml
+++ b/playbooks/base/post-ssh.yaml
@@ -1,0 +1,6 @@
+- hosts: all
+  # NOTE(pabelanger): We ignore_errors for the following tasks as not to fail
+  # successful jobs.
+  ignore_errors: yes
+  roles:
+    - remove-build-sshkey

--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -1,0 +1,11 @@
+- hosts: all
+  roles:
+    - add-build-sshkey
+    - start-zuul-console
+    - validate-host
+    - use-cached-repos
+#    - mirror-info
+#    - configure-mirrors
+    - role: fetch-zuul-cloner
+      destination: "/usr/zuul-env/bin/zuul-cloner"
+      repo_src_dir: "/home/zuul/src/github.com"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,5 +1,30 @@
 # Shared jobs specific to the OpenLab Project
 
+# Shared jobs specific to the OpenLab Project
+
+- job:
+    name: base
+    parent: null
+    description: |
+      A subset of what the 'base' job provides: the absolute minimum considered
+      required to run for any one job.
+      It doesn't set up cached git repositories, will not set up mirrors,
+      doesn't validate the node and does not generate an ARA report.
+      These tasks, if required, can be included by the dependant jobs
+      themselves on a need basis.
+    attempts: 1
+    pre-run: playbooks/base/pre.yaml
+    post-run:
+      - playbooks/base/post-ssh.yaml
+      - playbooks/base/post-logs.yaml
+    roles:
+      - zuul: theopenlab/zuul-jobs
+      - zuul: theopenlab/project-config
+    timeout: 1800
+    nodeset: ubuntu-xenial
+    secrets:
+      - site_logs
+
 # Common test base job
 - job:
     name: init-test

--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -1,0 +1,619 @@
+# Shared zuul config specific to the OpenStack Project
+# Contains definitions of pipelines
+
+- pipeline:
+    name: check
+    description: |
+      Newly uploaded patchsets enter this pipeline to receive an
+      initial +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action:
+            - opened
+            - changed
+            - reopened
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*recheck\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: recheck-mitaka
+    description: |
+      Commenting "recheck stable/mitaka" enter this pipeline to run tests on
+      stable/mitaka of OpenStack and receive an initial +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*recheck\s+stable\/mitaka\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: recheck-newton
+    description: |
+      Commenting "recheck stable/newton" enter this pipeline to run tests on
+      stable/newton of OpenStack and receive an initial +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*recheck\s+stable\/newton\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: recheck-ocata
+    description: |
+      Commenting "recheck stable/ocata" enter this pipeline to run tests on
+      stable/ocata of OpenStack and receive an initial +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*recheck\s+stable\/ocata\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: recheck-pike
+    description: |
+      Commenting "recheck stable/pike" enter this pipeline to run tests on
+      stable/pike of OpenStack and receive an initial +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*recheck\s+stable\/pike\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: recheck-queens
+    description: |
+      Commenting "recheck stable/queens" enter this pipeline to run tests on
+      stable/queens of OpenStack and receive an initial +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*recheck\s+stable\/queens\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: periodic
+    description: Jobs in this queue are triggered on a timer. UTC-0 and UTC-12
+    manager: independent
+    precedence: low
+    trigger:
+      timer:
+        - time: '0 0,12 * * *'
+    success:
+      mysql:
+    failure:
+      mysql:
+
+- pipeline:
+    name: merge-check
+    description: >
+      Each time a change merges, this pipeline verifies that all open changes
+      on the same project are still mergeable.
+    failure-message: Build failed (merge-check pipeline).
+    manager: independent
+    ignore-dependencies: true
+    precedence: low
+    trigger: {}
+
+- pipeline:
+    name: recheck-designate
+    description: |
+      Commenting "recheck designate" enter this pipeline to run designate tests
+      on master of OpenStack and receive an initial +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*recheck\s+designate\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: recheck-trove
+    description: |
+      Commenting "recheck trove" enter this pipeline to run trove tests
+      on master of OpenStack and receive an initial +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*recheck\s+trove\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: recheck-lbaas
+    description: |
+      Commenting "recheck lbaas" enter this pipeline to run lbaas tests
+      on master of OpenStack and receive an initial +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*recheck\s+lbaas\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: recheck-fwaas
+    description: |
+      Commenting "recheck fwaas" enter this pipeline to run fwaas tests
+      on master of OpenStack and receive an initial +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*recheck\s+fwaas\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: check-generic-cloud
+    description: |
+      Commenting "recheck" enter this pipeline to run tests against
+      generic clouds and receive an initial +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*recheck\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: cloud-provider-openstack-unittest
+    description: |
+      Commenting "/test cloud-provider-openstack-unittest" enter this pipeline to run
+      the unit tests of cloud-provider-openstack repo and receive an initial
+      +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action:
+            - opened
+            - changed
+            - reopened
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test cloud-provider-openstack-unittest\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/retest\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test all\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: cloud-provider-openstack-acceptance-test-lb-octavia
+    description: |
+      Commenting "/test cloud-provider-openstack-acceptance-test-lb-octavia" enter this pipeline to run
+      the test job of Kubernetes+OpenStack LBaaS scenarios and receive an initial
+      +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action:
+            - opened
+            - changed
+            - reopened
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test cloud-provider-openstack-acceptance-test-lb-octavia\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/retest\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test all\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: cloud-provider-openstack-acceptance-test-keystone-authentication-authorization
+    description: |
+      Commenting "/test cloud-provider-openstack-acceptance-test-keystone-authentication-authorization" enter this
+      pipeline to run the tests job of Kubernetes+OpenStack Keystone authentication/authorication
+      scenarios and receive an initial +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action:
+            - opened
+            - changed
+            - reopened
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test cloud-provider-openstack-acceptance-test-keystone-authentication-authorization\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/retest\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test all\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: cloud-provider-openstack-acceptance-test-k8s-cinder
+    description: |
+      Commenting "/test cloud-provider-openstack-acceptance-test-k8s-cinder" enter this pipeline to run
+      the tests job of Kubernetes+OpenStack cinder scenarios and receive an initial
+      +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action:
+            - opened
+            - changed
+            - reopened
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test cloud-provider-openstack-acceptance-test-k8s-cinder\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/retest\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test all\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: cloud-provider-openstack-acceptance-test-standalone-cinder
+    description: |
+      Commenting "/test cloud-provider-openstack-acceptance-test-standalone-cinder" enter this pipeline to run
+      the tests job of Kubernetes+OpenStack Cinder standalone scenarios and receive an initial
+      +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action:
+            - opened
+            - changed
+            - reopened
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test cloud-provider-openstack-acceptance-test-standalone-cinder\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/retest\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test all\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: cloud-provider-openstack-acceptance-test-csi-cinder
+    description: |
+      Commenting "/test cloud-provider-openstack-acceptance-test-csi-cinder" enter this pipeline to run
+      the tests job of Kubernetes+OpenStack Cinder CSI scenarios and receive an initial
+      +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action:
+            - opened
+            - changed
+            - reopened
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test cloud-provider-openstack-acceptance-test-csi-cinder\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/retest\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test all\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: cloud-provider-openstack-acceptance-test-flexvolume-cinder
+    description: |
+      Commenting "/test cloud-provider-openstack-acceptance-test-flexvolume-cinder" enter this pipeline to run
+      the tests job of Kubernetes+OpenStack Cinder flexvolume scenarios and receive an initial
+      +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action:
+            - opened
+            - changed
+            - reopened
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test cloud-provider-openstack-acceptance-test-flexvolume-cinder\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/retest\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test all\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: cloud-provider-openstack-acceptance-test-e2e-conformance
+    description: |
+      Commenting "/test cloud-provider-openstack-acceptance-test-e2e-conformance" enter this pipeline to run
+      the tests job of Kubernetes+OpenStack E2E conformance test scenarios and receive an initial
+      +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action:
+            - opened
+            - changed
+            - reopened
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test cloud-provider-openstack-acceptance-test-e2e-conformance\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/retest\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test all\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.10
+    description: |
+      Commenting "/test cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.10" enter this
+      pipeline to run the tests job of Kubernetes+OpenStack E2E conformance test scenarios and receive an initial
+      +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action:
+            - opened
+            - changed
+            - reopened
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1\.10\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/retest\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test all\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:

--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -2,6 +2,56 @@
 # "encrypt_secret.py" in zuul/tools/, following is a example to encrypt the username
 # echo "your_username" | ./encrypt_secret.py http://zuul-web-ip:9000/openlab theopenlab/openlab-zuul-jobs
 
+- secret:
+    name: site_logs
+    data:
+      fqdn: logs.openlabtesting.org
+      path: /srv/static/logs
+      ssh_known_hosts: |
+          |1|J8kEuqUiVZzvCp/yCPiiQIlMM40=|JVPLd3//ENTQimevuexWalwVmFM= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPLqsecsDkFcjUzbnlEGP24iFvcOZ0DMou8NnRmLZsJ+qeUnsec8h27SJyk2UrSm/x/K+y9EE03oeypSTWzquu0=
+      ssh_username: zuul
+      ssh_private_key: !encrypted/pkcs1-oaep
+        - Y/tkiw/B6pi1u5/uX/gf3S7iPAXVfSKNAv1kpGpVKV3ri/Cnu0AlO93vPZwPb8X6YOuBy
+          Qd1tcrFoS/tM1VDYsu7qEaaVu1ucW/eSRAq0+2Lx8lC8NpQzFMqw4FqnajE0oV3zy292+
+          ElZwhBpVyvl4pVz03FKbgntoxX2SM0sZcUB80FsuDuWlhD+FNPGjg5NI4M8zOEsXL8Waz
+          oG923aBRn5t1ggTmC8wAJy1TV1rRntYdwuDmVdn+gqwNupsv3mxungg/bGQArPkG85Ylz
+          nFLFgeiZrQysDn2AgvVpxt+rwN7E7cJAxYbaCyVX1I4xLn44RJ/k4D6x9xaXZ1CJSJ8Sh
+          FBn9itbiJoe7zqkITChxvCAUWlAbnIKWreMTkP7tSx5psv0achcKUooEA0JCpJWsgUMNW
+          mdngf5YhnuDow5xklZB+iOFIsycHtUDuuk+MvTP0GqwAYhkKfpzgv+yW7vjdACVyrEe0L
+          +JVO8EAjaYzFkJvjWSsBqEi/P+bnEWexmLb0435oS/1JhlLzjqSiaLhEJAWINTFXKYoY8
+          ShReLiVrO8PK4Ej6XRvPFPMGADbvxKV7G54kpkxkntbH4IDnL1bXkMcH7Ggtb/pQ6hmyt
+          YU6ymeocQRw4R7Irl6cQVMuQV2g9EJ74HjJ4VzheN9o5FPMjv0mUwel8C4/Uw8=
+        - lMni51VLNCE9LlepD+l1nqH3vEsCYljFVB7ADwVFJMSXcHEtjUhMSx1tFkz6rGlz5gcTV
+          gp7/0kcV2sTqQb1Y05pNdP4Ml5JvXRtckZ1mx4khTijZ75WBpyFgcYfgqq4XSvE1vQK+6
+          YbU3GSc6ChySqDrj9xWuK4Q3ssaFeGnGWmi3NC8YoiRkoiFUF6lk+Dsi3x63ov4vFMIlW
+          KiSc3A6OevDZrwf/c1LOJ9YIyB1kOPa/jauzacjxZDQiKmBs7GEzHT9V6VhUa43RaLL/+
+          MWIKgEJLJ0cUmUv2bkQX929OMA1ZarhWEUV6myzKI7vqQ7tAaXe5Aac14m8acp/KvBtl3
+          ywQLZx8FfPi4/wz/QW4ZQKSRha6d3/qSoGg6+P9e9AsUUWdKZc/0YR4CC+tJ1RVSxla6A
+          wjNCHx8X4wXH5s45IFn9CQnK4/taxx+3wzkyQhPvgaUtHDO7HqPJgZUp5mWso+wDUFrwL
+          Zo2AXVZu03jn/xoAdK+O65LjlGLysVEyVb+5RB1/usxsZtfn2NWvbgyvIWZVpix73Gqir
+          X/O9Fefp5jwqUG4W4UwVrFz1ABbL9wB5TLwptCZZukFNSflc4KJwsrXCncpFUL1LSHrH2
+          65rhzMao1WBHlbShYKfxu6q1XyFtrIO6FMTkEac8vPWtqS1Vnq77JIWX+YwzfE=
+        - VcXVvPZmfMvGsj9RhSKreFlO9nEO7yjra62MgS4PnoKoXOeQXFRCq1oSqwPl9InmCyab7
+          ZMQGCxiWMpWHuwO7ax7LvVQR7TrF4hp0rvjMeY+g4m9acrOODiivsrYtwPJg3dpNEHgxk
+          7YESrTPNIkhr/ud0qmQIf3ofl6vIIghbruW6Blwu1WoppGOUkbolFv+z/PSLF933KGLYY
+          vAIW6Z265dZjuH73zdYh6dytWOPPOu9XdZffKWFYkzD5GrsfZfLsZFGpqMUTQ+2RNewP6
+          CAis9K7bMwRm54i+1pqgxoPCWYLeUHJjGBzRiolOBnCoMGfAyQVhmoi9eMepWIcsr9SNk
+          EU73NRkQ9fXBA0fhLVKUDTZwhQ1AZns8T9XzvYBXDA7sbi6b3gRtMtRayVcTzPpeIpiwk
+          E3Tj2x8qWW34zBXmX3Q0gnE633NAZXODsCTj2zuajXGfZq3ewIfdgwZPk1YxlH9Bo6Uhv
+          4bcgEq4B7bFMC1ToT8y38JifU456MCovcIlHGcixte2aiOEFsQ1ZKAyjVod+ngZHSpYuW
+          oltFExxdrCHtCur8oED0wZlyqa+P4mF+HpMdpkEubgyR+xZwcPW+ebMWCuqQ0w8aUdnzm
+          CY70O7nid/TgIlC/oRBIfDSzPk0GzzQLYfwgWr6BpIG1gPmOg7BPG5ZrVt5stA=
+        - QsVnJcYeC/ijL5W5mMe+CkNB9O9wQL0Z/Vuby3K9AeHxoEjUF+mJLzdT2hI3cvobjob3S
+          /1yFxJW9m70iDBrpAfaZpUJFask/povQkvS+35CaFhc4JIALRIQ1N0+rKrcrLLKaFy1YZ
+          vghdYWX7WABy9jI+dXPUzTRR/g5f1cBUckYPPXR49HN/BidkfWKTRY2PqEwYm7e8tjE34
+          qUGcr0ALNH5oGgNBK3urDHuxW0vd7CyE+S33VAi0K6cdB4gE9ZObsbllIRtr2wTuPqPut
+          8mhqjgAv0QVYrZjw6Jg/L6FdD9E0Wwzn8mUu0tDLFO8T26STzv9dT5vvtL+hmPsDVR2hF
+          1xAb49rkUPEPoLdS9wIfogW63KFl2XlBnktt3i8Fjd1ofK5n/01kxFhof4zqX4wvFLcIY
+          wBO6ASFE9/6Kh6RhuVTvsJ19wqQtG3GPtGGbvAoIo7FrkLGUYJJg1t30UK4IMKJgh2M1x
+          Hem1xjHJJSTrhCcXss8+G2BQnizHwTLSe/FGwfeESrScbbSONgvybZvu++WRh0S4SbeNR
+          DhcH0LS3Oi+dqtBTi7ds6s2EWmcwA4QDRd/8cnI5CJx0+6peKctA5EatHS3y3GoliM85u
+          e0YHvDFAo0Cph7Krjb2nIY02FdoUV9ZzZC1Dt5ggLe01xhiB3PlFC3PtkkltsQ=
+
 # TODO: Deprecated for now, need to update when get new dedicated account
 - secret:
     name: telefonica_credentials


### PR DESCRIPTION
- Add the "base" job to openlab-zuul-jobs repo to get rid of project-config changes
- Move the "site_logs" secret to openlab-zuul-jobs
- Move pipelines definition from project-config to openlab-zuul-jobs