### PR TITLE
Skip the playbooks/base for ansible syntax checking

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -247,7 +247,7 @@
       - theopenlab/zuul-jobs
     run: playbooks/openlab-zuul-jobs-check/run.yaml
     vars:
-      excluded_path: ""
+      excluded_path: "playbooks/base/*"
 
 # Deprecated (Kubernetes nested scenario)
 - job:


### PR DESCRIPTION
Because the `ansible-playbook --syntax-check` command don't support
--skip-tags for now, see: http://github.com/ansible/ansible/issues/32536
The ansible-linter can support "skip_ansible_lint" taged tasks.