### PR TITLE
Add support for using config driver to request metadata

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
@@ -54,7 +54,11 @@
           export ALLOW_PRIVILEGED=true
           # Just kick off all the processes and drop down to the command line
           export ENABLE_DAEMON=true
-          export HOSTNAME_OVERRIDE=$(curl http://169.254.169.254/openstack/latest/meta_data.json | python -c "import sys, json; print json.load(sys.stdin)['name']")
+          if [ -d /mnt/config/openstack ]; then
+              export HOSTNAME_OVERRIDE=$(hostname)
+          else
+              export HOSTNAME_OVERRIDE=$(curl http://169.254.169.254/openstack/latest/meta_data.json | python -c "import sys, json; print json.load(sys.stdin)['name']")
+          fi
           export MAX_TIME_FOR_URL_API_SERVER=5
 
           # Requirements to deploy the csi cinder driver
@@ -81,7 +85,12 @@
           '{{ kubectl }}' create clusterrolebinding --user system:kube-controller-manager  kube-system-cluster-admin-6 --clusterrole cluster-admin
 
           # Where csi provisioner reads instance id from
-          INSTANCE_UUID=$(curl http://169.254.169.254/openstack/latest/meta_data.json | python -c "import sys, json; print json.load(sys.stdin)['uuid']")
+          # Where csi provisioner reads instance id from
+          if [ -d /mnt/config/openstack ]; then
+              INSTANCE_UUID=$(python -c "import json;print json.load(open('/mnt/config/openstack/latest/meta_data.json', 'r'))['uuid']")
+          else
+              INSTANCE_UUID=$(curl http://169.254.169.254/openstack/latest/meta_data.json | python -c "import sys, json; print json.load(sys.stdin)['uuid']")
+          fi
           echo "$INSTANCE_UUID" > /var/lib/cloud/data/instance-id
 
           # Build latest images from source

--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -59,7 +59,11 @@
           export MAX_TIME_FOR_URL_API_SERVER=5
 
           # setup all the host name and ip address(es)
-          export HOSTNAME_OVERRIDE=$(curl http://169.254.169.254/openstack/latest/meta_data.json | python -c "import sys, json; print json.load(sys.stdin)['name']")
+          if [ -d /mnt/config/openstack ]; then
+              export HOSTNAME_OVERRIDE=$(hostname)
+          else
+              export HOSTNAME_OVERRIDE=$(curl http://169.254.169.254/openstack/latest/meta_data.json | python -c "import sys, json; print json.load(sys.stdin)['name']")
+          fi
           export API_HOST=$HOSTNAME_OVERRIDE
           export EXTERNAL_HOSTNAME=$HOSTNAME_OVERRIDE
           export KUBELET_FLAGS="--node-ip $API_HOST_IP"

--- a/playbooks/cloud-provider-openstack-acceptance-test-k8s-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-k8s-cinder/run.yaml
@@ -55,7 +55,11 @@
           export ALLOW_PRIVILEGED=true
           # Just kick off all the processes and drop down to the command line
           export ENABLE_DAEMON=true
-          export HOSTNAME_OVERRIDE=$(curl http://169.254.169.254/openstack/latest/meta_data.json | python -c "import sys, json; print json.load(sys.stdin)['name']")
+          if [ -d /mnt/config/openstack ]; then
+              export HOSTNAME_OVERRIDE=$(hostname)
+          else
+              export HOSTNAME_OVERRIDE=$(curl http://169.254.169.254/openstack/latest/meta_data.json | python -c "import sys, json; print json.load(sys.stdin)['name']")
+          fi
           export MAX_TIME_FOR_URL_API_SERVER=5
 
           # -E preserves the current env vars, but we need to special case PATH

--- a/playbooks/cloud-provider-openstack-acceptance-test-keystone-authentication-authorization/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-keystone-authentication-authorization/run.yaml
@@ -84,7 +84,11 @@
           export ALLOW_PRIVILEGED=true
           # Just kick off all the processes and drop down to the command line
           export ENABLE_DAEMON=true
-          export HOSTNAME_OVERRIDE=$(curl http://169.254.169.254/openstack/latest/meta_data.json | python -c "import sys, json; print json.load(sys.stdin)['name']")
+          if [ -d /mnt/config/openstack ]; then
+              export HOSTNAME_OVERRIDE=$(hostname)
+          else
+              export HOSTNAME_OVERRIDE=$(curl http://169.254.169.254/openstack/latest/meta_data.json | python -c "import sys, json; print json.load(sys.stdin)['name']")
+          fi
           export MAX_TIME_FOR_URL_API_SERVER=5
           export AUTHORIZATION_MODE="Node,Webhook,RBAC"
 

--- a/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
@@ -61,7 +61,11 @@
           export ALLOW_PRIVILEGED=true
           # Just kick off all the processes and drop down to the command line
           export ENABLE_DAEMON=true
-          export HOSTNAME_OVERRIDE=$(curl http://169.254.169.254/openstack/latest/meta_data.json | python -c "import sys, json; print json.load(sys.stdin)['name']")
+          if [ -d /mnt/config/openstack ]; then
+              export HOSTNAME_OVERRIDE=$(hostname)
+          else
+              export HOSTNAME_OVERRIDE=$(curl http://169.254.169.254/openstack/latest/meta_data.json | python -c "import sys, json; print json.load(sys.stdin)['name']")
+          fi
           export MAX_TIME_FOR_URL_API_SERVER=5
 
           # -E preserves the current env vars, but we need to special case PATH

--- a/playbooks/cloud-provider-openstack-test/post.yaml
+++ b/playbooks/cloud-provider-openstack-test/post.yaml
@@ -11,7 +11,11 @@
           set -x
           pip install -U python-openstackclient
 
-          server_id=$(curl http://169.254.169.254/openstack/latest/meta_data.json | python -c "import sys, json; print json.load(sys.stdin)['uuid']")
+          if [ -d /mnt/config/openstack ]; then
+              server_id=$(python -c "import json;print json.load(open('/mnt/config/openstack/latest/meta_data.json', 'r'))['uuid']")
+          else
+              server_id=$(curl http://169.254.169.254/openstack/latest/meta_data.json | python -c "import sys, json; print json.load(sys.stdin)['uuid']")
+          fi
           pv_name=$('{{ kubectl }}' get pv | sed '1d' | awk '{print $1}')
           volume_id=$(openstack volume list | awk "/$pv_name/ {print \$2}")
           if [[ -n "$volume_id" ]]; then


### PR DESCRIPTION
This change to use config driver to get metadata of nodes if config driver supported, then will also try to request from 169.254.169.254 as an alternative.

Fix # theopenlab/openlab/issues/60