### PR TITLE
Use explict floating-network-id and subnet-id for lbaas job

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
@@ -30,8 +30,8 @@
           region = $OS_REGION_NAME
           [LoadBalancer]
           use-octavia = true
-          floating-network-id = $(openstack network list --external -f value -c ID | head -n 1)
-          subnet-id = $(openstack network list --internal -f value -c Subnets | head -n 1)
+          floating-network-id = $(openstack network show public -f value -c id)
+          subnet-id = $(openstack network show int-net -f value -c subnets)
           [BlockStorage]
           bs-version = v2
           ignore-volume-az = yes


### PR DESCRIPTION
Because seems in Vexxhost, sometimes openstack command can also list
other shared external networks, but only the 'public' network can be
used as floating ip network.

see: http://logs.openlabtesting.org/logs/65/165/579db7370ad5fbf2d5e0fab972bac115b6e2034d/cloud-provider-openstack-acceptance-test-lb-octavia/cloud-provider-openstack-acceptance-test-lb-octavia/f8ead38/job-output.txt.gz

related error messages:

2018-05-09 11:55:49.427719 | ubuntu-xenial-vexxhost |   Warning  UnAvailableLoadBalancer     9m (x2 over 10m)  service-controller  There are no available nodes for LoadBalancer service default/internal-http-nginx-service
2018-05-09 11:55:49.427937 | ubuntu-xenial-vexxhost |   Warning  CreatingLoadBalancerFailed  9m (x2 over 10m)  service-controller  Error creating load balancer (will retry): failed to ensure load balancer for service default/internal-http-nginx-service: there are no available nodes for LoadBalancer service default/internal-http-nginx-service
2018-05-09 11:55:49.428031 | ubuntu-xenial-vexxhost |   Normal   UpdatedLoadBalancer         8m                service-controller  Updated load balancer with new hosts
2018-05-09 11:55:49.428113 | ubuntu-xenial-vexxhost |   Normal   EnsuringLoadBalancer        3m (x7 over 10m)  service-controller  Ensuring load balancer
2018-05-09 11:55:49.428372 | ubuntu-xenial-vexxhost |   Warning  CreatingLoadBalancerFailed  3m (x5 over 9m)   service-controller  Error creating load balancer (will retry): failed to ensure load balancer for service default/internal-http-nginx-service: error creating LB floatingip {FloatingNetworkID:**119266fd-7204-407d-bef0-e2f35495469d** FloatingIP: PortID:64048718-125a-4354-b392-fa558f158144 FixedIP: SubnetID: TenantID: ProjectID:}: Resource not found

the 119266fd-7204-407d-bef0-e2f35495469d is a shared floating ip network belong to other project and cannot be used.
