### PR TITLE
install golang first for cloud-provider-openstack-format

### DIFF
--- a/playbooks/cloud-provider-openstack-format/run.yaml
+++ b/playbooks/cloud-provider-openstack-format/run.yaml
@@ -1,5 +1,7 @@
 - hosts: all
   become: yes
+  roles:
+    - install-golang
   tasks:
     - name: Run gofmt and typo checking of cloud-provider-openstack
       shell:


### PR DESCRIPTION
Golang has to be installed first to make sure `gofmt` existed.

This is the root cause that causing kubernetes/cloud-provider-openstack#154 failing.

/cc @dims 