### PR TITLE
Deprecated ubuntu-xenial-otc nodeset

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -198,7 +198,7 @@
     description: |
       Run Kubernetes openstack-cloud-controller-manager unit test in devstack instance
     run: playbooks/cloud-provider-openstack-unittest-nested/run.yaml
-    nodeset: ubuntu-xenial-otc
+    nodeset: ubuntu-xenial
 
 # Kubernetes cloud-provider-openstack jobs
 - job:

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -19,12 +19,6 @@
         label: ubuntu-xenial-ut
 
 - nodeset:
-    name: ubuntu-xenial-otc
-    nodes:
-      - name: ubuntu-xenial-otc
-        label: ubuntu-xenial-otc
-
-- nodeset:
     name: ubuntu-xenial-vexxhost
     nodes:
       - name: ubuntu-xenial-vexxhost


### PR DESCRIPTION
**ubuntu-xenial-otc** nodeset is only used in cloud-provider-openstack nested
vm scenario, no project refer this job **cloud-provider-openstack-unittest-nested**,
so we can deprecate nodeset at first.

Closes: theopenlab/openlab#61