### PR TITLE
Fix the Mitaka devstack installation

### DIFF
--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -149,6 +149,7 @@
   environment: '{{ zuul | zuul_legacy_vars }}'
   when:
     - '"zun" in enable_services'
+    - os_branch != 'stable/mitaka'
 
 - name: create devstack local conf with ceph enabled
   shell:

--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -12,6 +12,23 @@
     apt install libpcre3-dev -y
   ignore_errors: yes
 
+- name: workaround devstack installation on stable/mitaka branch
+  shell:
+    cmd: |
+      set -e
+      set -x
+      # Because the pip10 cannot uninstall/upgrade the pre-installed distutils packages
+      # see: https://github.com/pypa/pip/issues/4805
+      sed -i '/"Running gate_hook"/ a\
+                sed -i "s/pip!=8/pip!=8,<10.0.0/" /opt/stack/new/devstack/tools/cap-pip.txt' '{{ ansible_user_dir }}/workspace/devstack-gate/devstack-vm-gate-wrap.sh'
+      # Because in setuptools>=39, the pkg_resources.parse_version(oslo_utils/versionutils.py) will return an unindexable object
+      pip install "setuptools==38.0.0"
+    executable: /bin/bash
+    chdir: '{{ ansible_user_dir }}/workspace'
+  environment: '{{ zuul | zuul_legacy_vars }}'
+  when:
+    - os_branch == 'stable/mitaka'
+
 - name: Install devstack on {{ os_branch }} branch
   shell:
     cmd: |


### PR DESCRIPTION
- Cap the pip version to be 9.0.0, because the latest pip 10 cannot uninstall/upgrade the distutils packages
- Do not install Zun in Mitaka installation as the devstack has been broken for Mitaka
- Cap the setuptools to be 38.0.0, because the latest 39 version cannot work with oslo.utils 3.8.0 which is the limitation for Mitaka devstack

Fix # theopenlab/openlab/issues/65