### PR TITLE
Upload multiple junit files to avoid test timeout

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/post.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/post.yaml
@@ -1,4 +1,6 @@
 - hosts: all
+  roles:
+    - export-gcp-account
   become: yes
   tasks:
     - name: Upload E2E conformance test result to kubernetes testgrid
@@ -21,11 +23,9 @@
           if [ '{{ zuul.pipeline }}' != 'periodic' ]; then
               PIPELINE_LOGS_DIR='pr-logs'
           fi
-          # download google account key file
-          echo '{{ gcp_account.key_json }}' > /tmp/key.json
           # upload e2e log to google storage
-          python upload_e2e.py --junit=$LOG_DIR/junit_01.xml --log=$LOG_DIR/e2e.log \
+          python upload_e2e.py --junit=$LOG_DIR/junit*.xml --log=$LOG_DIR/e2e.log \
               --bucket=gs://k8s-conformance-openstack/$PIPELINE_LOGS_DIR/ci-'{{ zuul.job }}' \
-              --key-file=/tmp/key.json
+              --key-file='{{ hostvars[inventory_hostname]["gcp_key_file"] }}'
         executable: /bin/bash
       environment: '{{ golang_env }}'

--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -118,7 +118,7 @@
               --provider=local \
               --ginkgo-parallel=1 \
               --test_args="--ginkgo.focus=\\[Conformance\\] --ginkgo.noColor=true" \
-              --timeout=120m | tee $LOG_DIR/e2e.log
+              --timeout=150m | tee $LOG_DIR/e2e.log
         executable: /bin/bash
         chdir: '{{ k8s_os_provider_src_dir }}'
       environment: '{{ golang_env }}'

--- a/roles/export-gcp-account/tasks/main.yaml
+++ b/roles/export-gcp-account/tasks/main.yaml
@@ -1,0 +1,11 @@
+- name: Set google account key file path
+  set_fact:
+    gcp_key_file: '/tmp/gcp_key.json'
+  no_log: yes
+
+- name: Save google account key file
+  shell:
+    cmd: |
+      echo '{{ gcp_account.key_json }}' > '{{ hostvars[inventory_hostname]["gcp_key_file"] }}'
+    executable: /bin/bash
+  no_log: yes


### PR DESCRIPTION
- use "--junit=/path-to/junit*.xml" to upload junit files
- change conformance test timeout from 120m to 150m
- avoid to echo gcp account info

Related-Issue: theopenlab/openlab#64