### PR TITLE
Do not replace q-* services with neutron-* service in Mitaka

### DIFF
--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -13,7 +13,7 @@
   environment: '{{ zuul | zuul_legacy_vars }}'
 
 # Use neutron-* services to replace q-* services except Mitaka
-- name: create devstack local conf header
+- name: enable neutron services by new services names
   shell:
     cmd: |
       set -e

--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -7,12 +7,26 @@
       cat << EOF >> /tmp/dg-local.conf
       [[local|localrc]]
       NETWORK_GATEWAY=10.0.0.1
+      EOF
+    executable: /bin/bash
+    chdir: '{{ ansible_user_dir }}/workspace'
+  environment: '{{ zuul | zuul_legacy_vars }}'
+
+# Use neutron-* services to replace q-* services except Mitaka
+- name: create devstack local conf header
+  shell:
+    cmd: |
+      set -e
+      set -x
+      cat << EOF >> /tmp/dg-local.conf
       disable_service q-agt q-svc q-dhcp q-l3 q-meta q-metering
       enable_service neutron-agent neutron-api neutron-dhcp neutron-l3 neutron-metadata-agent neutron-metering
       EOF
     executable: /bin/bash
     chdir: '{{ ansible_user_dir }}/workspace'
   environment: '{{ zuul | zuul_legacy_vars }}'
+  when:
+    - os_branch != 'stable/mitaka'
 
 
 # Populate local conf with specific branch


### PR DESCRIPTION
Because In Mitaka devstack installation, it cannot handle the neutron-* services, see:
http://logs.openlabtesting.org/logs/13/1013/6978c44eae5d453cc0780d2e684477ae94a33889/recheck-mitaka/gophercloud-acceptance-test-mitaka/c780ab2/