### PR TITLE
Config OCTAVIA_MGMT_SUBNET to avoid IP conflicting

### DIFF
--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -99,6 +99,8 @@
       enable_plugin neutron-lbaas https://git.openstack.org/openstack/neutron-lbaas
       enable_plugin octavia https://git.openstack.org/openstack/octavia
       enable_plugin barbican https://git.openstack.org/openstack/barbican
+      # Avoid to confict with vm fixed ip in some public cloud
+      OCTAVIA_MGMT_SUBNET=192.168.10.0/24
       EOF
     executable: /bin/bash
   when:
@@ -113,6 +115,8 @@
       enable_service octavia,o-cw,o-hm,o-hk,o-api
       enable_plugin octavia https://git.openstack.org/openstack/octavia
       enable_plugin barbican https://git.openstack.org/openstack/barbican
+      # Avoid to confict with vm fixed ip in some public cloud
+      OCTAVIA_MGMT_SUBNET=192.168.10.0/24
       EOF
     executable: /bin/bash
   when:


### PR DESCRIPTION
Default value of OCTAVIA_MGMT_SUBNET is "192.168.0.0/24", but
in some public cloud fixed ip of zuul testing vm also is in same
subnet "192.168.0.0/24", that cause lb agent can not update lb vm
status.

Related-Bug: theopenlab/openlab#69