### PR TITLE
Support to test against multi release OpenStack in packer and ansible

### DIFF
--- a/playbooks/ansible-functional-devstack/run.yaml
+++ b/playbooks/ansible-functional-devstack/run.yaml
@@ -2,6 +2,7 @@
   become: yes
   roles:
     - clone-devstack-gate-to-workspace
+    - create-devstack-local-conf
     - install-devstack
     - ensure-tox
     - role: tox

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -190,6 +190,7 @@
     run: playbooks/openlab-zuul-jobs-check/run.yaml
     vars:
       excluded_path: "playbooks/base/*"
+    nodeset: ubuntu-xenial-ut
 
 # Deprecated (Kubernetes nested scenario)
 - job:
@@ -368,6 +369,87 @@
       os_sdk: openstacksdk
 
 - job:
+    name: openstacksdk-ansible-stable-2.6-functional-devstack-queens
+    parent: init-test
+    description: |
+      Run openstacksdk ansible functional tests against a queens devstack
+      using git stable-2.6 branch version of ansible.
+    run: playbooks/ansible-functional-devstack/run.yaml
+    required-projects:
+      - name: ansible/ansible
+        override-checkout: stable-2.6
+      - openstack/openstacksdk
+    vars:
+      os_sdk: openstacksdk
+      global_env:
+        OS_BRANCH: stable/queens
+
+- job:
+    name: openstacksdk-ansible-stable-2.6-functional-devstack-pike
+    parent: init-test
+    description: |
+      Run openstacksdk ansible functional tests against a pike devstack
+      using git stable-2.6 branch version of ansible.
+    run: playbooks/ansible-functional-devstack/run.yaml
+    required-projects:
+      - name: ansible/ansible
+        override-checkout: stable-2.6
+      - openstack/openstacksdk
+    vars:
+      os_sdk: openstacksdk
+      global_env:
+        OS_BRANCH: stable/pike
+
+- job:
+    name: openstacksdk-ansible-stable-2.6-functional-devstack-ocata
+    parent: init-test
+    description: |
+      Run openstacksdk ansible functional tests against a ocata devstack
+      using git stable-2.6 branch version of ansible.
+    run: playbooks/ansible-functional-devstack/run.yaml
+    required-projects:
+      - name: ansible/ansible
+        override-checkout: stable-2.6
+      - openstack/openstacksdk
+    vars:
+      os_sdk: openstacksdk
+      global_env:
+        OS_BRANCH: stable/ocata
+
+- job:
+    name: openstacksdk-ansible-stable-2.6-functional-devstack-newton
+    parent: init-test
+    description: |
+      Run openstacksdk ansible functional tests against a newton devstack
+      using git stable-2.6 branch version of ansible.
+    run: playbooks/ansible-functional-devstack/run.yaml
+    required-projects:
+      - name: ansible/ansible
+        override-checkout: stable-2.6
+      - openstack/openstacksdk
+    vars:
+      os_sdk: openstacksdk
+      global_env:
+        OS_BRANCH: stable/newton
+
+- job:
+    name: openstacksdk-ansible-stable-2.6-functional-devstack-mitaka
+    parent: init-test
+    description: |
+      Run openstacksdk ansible functional tests against a mitaka devstack
+      using git stable-2.6 branch version of ansible.
+    run: playbooks/ansible-functional-devstack/run.yaml
+    required-projects:
+      - name: ansible/ansible
+        override-checkout: stable-2.6
+      - openstack/openstacksdk
+    vars:
+      os_sdk: openstacksdk
+      global_env:
+        OS_BRANCH: stable/mitaka
+    nodeset: ubuntu-trusty
+
+- job:
     name: shade-ansible-stable-2.5-functional-devstack
     parent: init-test
     description: |
@@ -474,10 +556,66 @@
     name: packer-1.2.5-functional-devstack
     parent: init-test
     description: |
-      Test image building functionality of Packer of version 1.2.5 against devstack.
+      Test image building functionality of Packer of version 1.2.5 against master devstack.
     run: playbooks/packer-functional-devstack/run.yaml
     vars:
       packer_version: 1.2.5
+
+- job:
+    name: packer-1.2.5-functional-devstack-queens
+    parent: init-test
+    description: |
+      Test image building functionality of Packer of version 1.2.5 against queens devstack.
+    run: playbooks/packer-functional-devstack/run.yaml
+    vars:
+      packer_version: 1.2.5
+      global_env:
+        OS_BRANCH: stable/queens
+
+- job:
+    name: packer-1.2.5-functional-devstack-pike
+    parent: init-test
+    description: |
+      Test image building functionality of Packer of version 1.2.5 against pike devstack.
+    run: playbooks/packer-functional-devstack/run.yaml
+    vars:
+      packer_version: 1.2.5
+      global_env:
+        OS_BRANCH: stable/pike
+
+- job:
+    name: packer-1.2.5-functional-devstack-ocata
+    parent: init-test
+    description: |
+      Test image building functionality of Packer of version 1.2.5 against ocata devstack.
+    run: playbooks/packer-functional-devstack/run.yaml
+    vars:
+      packer_version: 1.2.5
+      global_env:
+        OS_BRANCH: stable/ocata
+
+- job:
+    name: packer-1.2.5-functional-devstack-newton
+    parent: init-test
+    description: |
+      Test image building functionality of Packer of version 1.2.5 against newton devstack.
+    run: playbooks/packer-functional-devstack/run.yaml
+    vars:
+      packer_version: 1.2.5
+      global_env:
+        OS_BRANCH: stable/newton
+
+- job:
+    name: packer-1.2.5-functional-devstack-mitaka
+    parent: init-test
+    description: |
+      Test image building functionality of Packer of version 1.2.5 against mitaka devstack.
+    run: playbooks/packer-functional-devstack/run.yaml
+    vars:
+      packer_version: 1.2.5
+      global_env:
+        OS_BRANCH: stable/mitaka
+    nodeset: ubuntu-trusty
 
 - job:
     name: docker-machine-0.15.0-functional-opentelekomcloud

--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -151,6 +151,30 @@
       mysql:
 
 - pipeline:
+    name: recheck-rocky
+    description: |
+      Commenting "recheck stable/rocky" enter this pipeline to run tests on
+      stable/rocky of OpenStack and receive an initial +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*recheck\s+stable\/rocky\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
     name: periodic
     description: Jobs in this queue are triggered on a timer. UTC-0 0:00, 8:00 and 16:00
     manager: independent

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -37,6 +37,18 @@
             branches: stable-2.6
         - openstacksdk-ansible-stable-2.6-functional-orange:
             branches: stable-2.6
+        - openstacksdk-ansible-stable-2.6-functional-devstack:
+            branches: stable-2.6
+        - openstacksdk-ansible-stable-2.6-functional-devstack-queens:
+            branches: stable-2.6
+        - openstacksdk-ansible-stable-2.6-functional-devstack-pike:
+            branches: stable-2.6
+        - openstacksdk-ansible-stable-2.6-functional-devstack-ocata:
+            branches: stable-2.6
+        - openstacksdk-ansible-stable-2.6-functional-devstack-newton:
+            branches: stable-2.6
+        - openstacksdk-ansible-stable-2.6-functional-devstack-mitaka:
+            branches: stable-2.6
 
 - project:
     name: theopenlab/packer
@@ -51,6 +63,16 @@
         - packer-1.2.5-functional-huaweicloud:
             branches: master
         - packer-1.2.5-functional-devstack:
+            branches: master
+        - packer-1.2.5-functional-devstack-queens:
+            branches: master
+        - packer-1.2.5-functional-devstack-pike:
+            branches: master
+        - packer-1.2.5-functional-devstack-ocata:
+            branches: master
+        - packer-1.2.5-functional-devstack-newton:
+            branches: master
+        - packer-1.2.5-functional-devstack-mitaka:
             branches: master
     check:
       jobs:


### PR DESCRIPTION
1. add recheck-rocky pipeline.
2. add packer v1.2.5 and M/N/O/P/Q openstack test jobs,
   add these into periodic pipeline.
3. add ansible 2.6 and M/N/O/P/Q openstack test jobs,
   add these into periodic pipeline.
4. add role create-devstack-local-conf into ansible devstack
   job to support mutliple release install.
5. make openlab check job to use UT nodeset.

Related-Bug: theopenlab/openlab#74