### PR TITLE
Unset AZ env and correct the orange auth_url to fix docker machine jobs

### DIFF
--- a/playbooks/docker-machine-functional-public-clouds/run.yaml
+++ b/playbooks/docker-machine-functional-public-clouds/run.yaml
@@ -47,6 +47,9 @@
           export OS_FLOATINGIP_POOL="admin_external_net"
           export OS_SECURITY_GROUPS="openlab-jobs-sg"
           export OS_SSH_USER="{{ ssh_user | default('ubuntu') }}"
+
+          # NOTE: We do not need AZ environment variable, so unset in case it has been set in cloud openrc
+          unset OS_AVAILABILITY_ZONE
           pushd $GOPATH/src/github.com/docker/machine
           DEBUG=true VERBOSE=true DRIVER=openstack make test-integration test/integration/core/
           popd

--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -133,16 +133,16 @@
       auth_type: password
       identity_api_version: "3"
       auth_url: !encrypted/pkcs1-oaep
-        - TPk2XANBMM3ggAY0IrnL/XO+55Lnfx7IlBA/3JBsBrkNtiuYnNiIAMyyvMVE+JTObo98b
-          lkTyOlolQ02Aq5yQmtzHqrpH2t1E3An+vSREHbUtthfMSrlsWnBD3VqNwTl4cAao3Ar0J
-          J5CBe1/UsfEXFfFp3L7YWj9jQa6qJrn2uoJ2K3Jku8E1uN9qlijKLNjcRT/pcbIb7vtGM
-          OD+IeynBhfD2YKN5fJrEvSZIz9TtiM7nZr4uRa8hjQo2QEiexLDAydhFbcr1jA8Bgr6F0
-          JcbEeIoQvV8US7VnmScBtMMUczho8O/deBB75OzDw4FAAOZnrHFaOu4hcgGAVB2jyAOJU
-          sBkPn+gQ2ZI8Fx6Iwzu107SA7pFfGOP4oJX75qHTCFzdwzBpBe0UbP65Hknxx951yXWzf
-          IzAd/k8nrB2C9xmI2jb9Kzi1NmLPEr8zmxJ5u/3AjycePGhWQ2yXaiS1lGIuHNP44AH/U
-          QwiU2Qsph2Cs1p0OVJE3krzaVcTJYVy8JHP2TO8I7rsNBV0Je9pMekZiZBfeNn4KbtOm8
-          atlUCEvMdqF7eaThlIiYaqIWt/6VdDihzqQNVAVYZ3NvsY2f//D2Uc27A36w9zjR4AGOc
-          yUT11Ia2Jvo8yPJnO28O2pWUt8AqIokTkPXdSDqrMhB4HRvdakDnFDiQD8mzWI=
+        - BBkbfwS02xXUzk+JejNrobWbvar+2ZcHtBXBbw16rgOKyW+IjPX3RMi/tCfElRbtg/x3Y
+          F/S/SgGiS48U7MhcrBFiN/TgWbHEYOZRvk0uhzchxYTAzs6FizFMEU61t+/YA/dggjmvN
+          Ya4IU08M+A0G7IIxDCkXAzSwNSbIQmq4bgBA70eKlZMARKtyNWuAjs002bFug4N04csfq
+          4rEQokJCPYW1f9OQa8sIlHzFHJrUm0qqGe5XRzxknB/zL0uRRbcMiJOshExU+l2HWFPdL
+          60lyHpANsQWETdmAdOTs/fUbXpJIXraj8TaSKmOS8Kn7VbF5rvrdFYg8w9D54zK7lulRd
+          eJ0Wp0y9Z+U8JEJ8q1/iSZe0YFojsvidDLyyYY5YFDeImImpkdGdW4akz3q7QjVBSC7wP
+          nwvVwcUy6HrwIDiHiVlemDsnUt0w9CvBlaWfvtGDFOAnKCt+U/o8ekgLXr6b9u7GwCZZy
+          +DJJmalR8RFxvXMJ0W2N9gvwamkL4eFczaq3vJIAz7kpVmZJfbZ5bf2Y6/rEippnnyOej
+          PMssRt3rNK/z7Eltr6+rTB23jtSaqtHZbIxuStJeQmD9rB47UaR4uhu6AgzxXM/GOwAo9
+          S+3MJu7/cKttGzk5PDWNqaub3eWhvt832VCmPg/xhDpoN5CHmMyzRKYrNE7Ofg=
       password: !encrypted/pkcs1-oaep
         - RyMZqCOCEt3uz5AHE7P3EJfJk1+PqL/EFhodIn3SmWIUsYCv5e+AmMPxEzmq26aJxN7OR
           KnJ9h8sYsB9pfhd5ZWpeMqCce9HffimiUjd7eyl0R6s//I3B21VgwomjEugzyEPHo4bJ1


### PR DESCRIPTION
- The `OS_AVAILABILITY_ZONE` env will be set in `export-cloud-openrc` in opentelekomcloud, which will cause error in docker machine jobs, this PR unset the variable in docker machine job
- The `auth_url`  of orange cloud in secrets don't include a "/v3" postfix, which will cause error in docker machine testing cases. This PR correct it.