### PR TITLE
Fix ansible testing fails

### DIFF
--- a/playbooks/ansible-functional-public-clouds/run.yaml
+++ b/playbooks/ansible-functional-public-clouds/run.yaml
@@ -53,7 +53,6 @@
     - name: modify sdk test scripts
       shell: |
         sed -i -e 's/ -vvv//g' ./extras/run-ansible-tests.sh
-        sed -i -e 's/^passenv = HOME USER$/passenv = HOME USER ANSIBLE_VAR_*/g' tox.ini
       args:
         executable: /bin/bash
         chdir: '{{ sdk_src_dir }}'
@@ -78,8 +77,7 @@
         tox_extra_args: "--notest"
 
     - name: Run test cases
-      # Disable public cloud policy limit roles: group keystone_domain keystone_role nova_flavor user user_group
-      shell: tox -eansible -- -c "{{ cloud_name }}" auth image keypair network object port router security_group server subnet volume
+      shell: tox -eansible -- -c "{{ cloud_name }}" "{{ test_cases }}"
       args:
         executable: /bin/bash
         chdir: '{{ sdk_src_dir }}'
@@ -89,5 +87,7 @@
         ANSIBLE_VAR_floating_ip_pool_name: "admin_external_net"
         ANSIBLE_VAR_enable_subnet_dhcp: "true"
         ANSIBLE_VAR_network_external: "false"
+        ANSIBLE_VAR_no_security_groups: "false"
+        ANSIBLE_VAR_boot_volume_size: "40"
       register: testing_output
       failed_when: "'FAILED' in testing_output.stdout or 'ERROR' in testing_output.stdout"

--- a/playbooks/packer-functional-devstack/run.yaml
+++ b/playbooks/packer-functional-devstack/run.yaml
@@ -50,7 +50,12 @@
           # in M and N release, so we have to filter "default" sg of current project by project id.
           project_id=$(openstack token issue -f value -c project_id)
           sg_id=$(openstack security group list | grep default | grep $project_id | head -n 1 | awk '{print $2}')
-          openstack security group rule create --ingress --protocol tcp --dst-port 22 $sg_id
+          # NOTE: openstackclient CLI options are not compatible in Mitaka and other release
+          if [ "{{ global_env.OS_BRANCH }}" == "stable/mitaka" ]; then
+              openstack security group rule create --proto tcp --dst-port 22 $sg_id
+          else
+              openstack security group rule create --ingress --protocol tcp --dst-port 22 $sg_id
+          fi
           packer validate os-template.json
           packer build -color=false os-template.json
           openstack image show $image_name

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -477,6 +477,8 @@
     vars:
       cloud_name: opentelekomcloud
       os_sdk: openstacksdk
+      # Disable public cloud policy limit roles: group keystone_domain keystone_role nova_flavor user user_group
+      test_cases: auth image keypair network object port router security_group server subnet volume
     secrets:
       - opentelekomcloud_credentials
 
@@ -494,8 +496,48 @@
     vars:
       cloud_name: orange
       os_sdk: openstacksdk
+      # Disable public cloud policy limit roles: group keystone_domain keystone_role nova_flavor user user_group object
+      test_cases: auth image keypair network port router security_group server subnet volume
     secrets:
       - orange_credentials
+
+- job:
+    name: openstacksdk-ansible-stable-2.6-functional-telefonica
+    parent: init-test
+    description: |
+      Run openstacksdk ansible functional tests against telefonica cloud
+      using git stable-2.6 branch version of ansible.
+    run: playbooks/ansible-functional-public-clouds/run.yaml
+    required-projects:
+      - name: ansible/ansible
+        override-checkout: stable-2.6
+      - openstack/openstacksdk
+    vars:
+      cloud_name: telefonica
+      os_sdk: openstacksdk
+      # Disable public cloud policy limit roles: group keystone_domain keystone_role nova_flavor user user_group object
+      test_cases: auth image keypair network port router security_group server subnet volume
+    secrets:
+      - telefonica_credentials
+
+- job:
+    name: openstacksdk-ansible-stable-2.6-functional-huaweicloud
+    parent: init-test
+    description: |
+      Run openstacksdk ansible functional tests against huaweicloud
+      using git stable-2.6 branch version of ansible.
+    run: playbooks/ansible-functional-public-clouds/run.yaml
+    required-projects:
+      - name: ansible/ansible
+        override-checkout: stable-2.6
+      - openstack/openstacksdk
+    vars:
+      cloud_name: huaweicloud
+      os_sdk: openstacksdk
+      # Disable public cloud policy limit roles: group keystone_domain keystone_role nova_flavor user user_group object
+      test_cases: auth image keypair network port router security_group server subnet volume
+    secrets:
+      - huaweicloud_credentials
 
 - job:
     name: packer-1.2.5-functional-opentelekomcloud

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -37,6 +37,10 @@
             branches: stable-2.6
         - openstacksdk-ansible-stable-2.6-functional-orange:
             branches: stable-2.6
+        - openstacksdk-ansible-stable-2.6-functional-telefonica:
+            branches: stable-2.6
+        - openstacksdk-ansible-stable-2.6-functional-huaweicloud:
+            branches: stable-2.6
         - openstacksdk-ansible-stable-2.6-functional-devstack:
             branches: stable-2.6
         - openstacksdk-ansible-stable-2.6-functional-devstack-queens:


### PR DESCRIPTION
1. Disable container test cases for orange, telefonica and huawei cloud.
2. Specified booting volume size and no_security_group option.
3. Add ansible 2.6 jobs for telefonica and huaweicloud into periodic
pipeline.

Depends-On: https://review.openstack.org/#/c/590078/
Close theopenlab/openlab#78