### PR TITLE
Add OS_DOMAIN_ID env for Packer job with Mitaka devstack

### DIFF
--- a/playbooks/packer-functional-devstack/run.yaml
+++ b/playbooks/packer-functional-devstack/run.yaml
@@ -53,6 +53,7 @@
           # NOTE: openstackclient CLI options are not compatible in Mitaka and other release
           if [ "{{ global_env.OS_BRANCH }}" == "stable/mitaka" ]; then
               openstack security group rule create --proto tcp --dst-port 22 $sg_id
+              export OS_DOMAIN_ID=default
           else
               openstack security group rule create --ingress --protocol tcp --dst-port 22 $sg_id
           fi


### PR DESCRIPTION
Packer Tests need the OS_DOMAIN_ID or OS_DOMAIN_NAME env variable set when using v3 identity services.