### PR TITLE
Manila-provisioner job fix

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-manila-provisioner/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-manila-provisioner/run.yaml
@@ -39,6 +39,12 @@
           export HOSTNAME_OVERRIDE=127.0.0.1
           export MAX_TIME_FOR_URL_API_SERVER=5
 
+          # -E preserves the current env vars, but we need to special case PATH
+          # Must run local-up-cluster.sh under kubernetes root directory
+          pushd '{{ k8s_src_dir }}'
+          sudo -E PATH=$PATH SHELLOPTS=$SHELLOPTS ./hack/local-up-cluster.sh -O
+          popd
+
           nohup ./manila-provisioner --provisioner=manila-provisioner --kubeconfig /var/run/kubernetes/admin.kubeconfig > "$LOG_DIR/manila-provisioner.log" 2>&1 &
 
           # set up the config we need for kubectl to work

--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -187,7 +187,8 @@
       ENABLE_CEPH_GLANCE=False
       ENABLE_CEPH_C_BAK=False
       ENABLE_CEPH_NOVA=False
-      ENABLE_CEPH_MANILA=False
+      ENABLE_CEPH_MANILA=True
+      MANILA_CEPH_DRIVER=cephfsnative
       EOF
     executable: /bin/bash
   when:

--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -610,7 +610,7 @@
     name: cloud-provider-openstack-acceptance-test-manila-provisioner
     description: |
       Commenting "/test cloud-provider-openstack-acceptance-test-manila-provisioner" enter this pipeline to run
-      the tests job of Kubernetes+OpenStack Cinder standalone scenarios and receive an initial
+      the tests job of Kubernetes+OpenStack Manila scenarios and receive an initial
       +/-1 Verified vote.
     manager: independent
     trigger:


### PR DESCRIPTION
This PR:
- fixes the job for cloud-provider-openstack manila-provisioner
- fixes a comment in zuul.d/pipelines
- `create-devstack-local-conf` role: enables Ceph for Manila and sets Manila's Ceph driver to `cephfsnative`. This can be achieved in different ways (maybe this should go in a separate task if this approach is not ok?). Reference https://github.com/openstack/manila/blob/master/playbooks/legacy/manila-tempest-minimal-dsvm-cephfs-native-centos-7/run.yaml#L60