### PR TITLE
Use security group "openlab-jobs-sg" for packer tests

### DIFF
--- a/playbooks/packer-functional-public-clouds/run.yaml
+++ b/playbooks/packer-functional-public-clouds/run.yaml
@@ -29,6 +29,7 @@
                       "source_image_name": "$src_img_name",
                       "ssh_username": "cirros",
                       "networks": ["$network"],
+                      "security_groups": ["openlab-jobs-sg"],
                       "floating_ip_pool": "admin_external_net"
                   }
               ],


### PR DESCRIPTION
We use "default" security group for packer tests again public clouds,
but "default" is shared sg, rules of "default" sg might be changed by
other, that might cause packer tests failing, so use "openlab-jobs-sg"
in stead of "default".