### PR TITLE
manila-provisioner job: add devstack-plugin-ceph

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-manila-provisioner/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-manila-provisioner/run.yaml
@@ -8,7 +8,9 @@
       enable_services:
         - 'manila'
         - 'ceph'
-    - install-devstack
+    - role: install-devstack
+      environment:
+        PROJECTS: 'openstack/devstack-plugin-ceph'
   tasks:
     - name: Run Manila provisioner acceptance tests
       shell:


### PR DESCRIPTION
Adds `openstack/devstack-plugin-ceph` to `install-devstack`, should fix the error in http://logs.openlabtesting.org/logs/67/267/6d54444f535424f6bdd95cb1ef7e1ed4f933376b/cloud-provider-openstack-acceptance-test-manila-provisioner/cloud-provider-openstack-acceptance-test-manila-provisioner/1e275c1/logs/devstacklog.txt.gz