### PR TITLE
manila-provisioner job: modify enabled services

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-manila-provisioner/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-manila-provisioner/run.yaml
@@ -10,6 +10,7 @@
         - 'ceph'
     - role: install-devstack
       environment:
+        OVERRIDE_ENABLED_SERVICES: 'dstat,g-api,g-reg,key,mysql,n-api,n-api-meta,n-cauth,n-cond,n-cpu,n-novnc,n-obj,n-sch,placement-api,q-agt,q-dhcp,q-l3,q-meta,q-metering,q-svc,rabbit'
         PROJECTS: 'openstack/devstack-plugin-ceph'
   tasks:
     - name: Run Manila provisioner acceptance tests


### PR DESCRIPTION
This PR modifies the list of enabled services in manila-provisioner job. There might be still some left that are not needed but should at least fix the issue where etcd was ran twice (once by k8s and once as a separate service).