### PR TITLE
Fix devstack Mitaka deployment failed

### DIFF
--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -23,6 +23,8 @@
                 sed -i "s/pip!=8/pip!=8,<10.0.0/" /opt/stack/new/devstack/tools/cap-pip.txt' '{{ ansible_user_dir }}/workspace/devstack-gate/devstack-vm-gate-wrap.sh'
       # Because in setuptools>=39, the pkg_resources.parse_version(oslo_utils/versionutils.py) will return an unindexable object
       pip install "setuptools==38.0.0"
+      # Fix issue https://github.com/theopenlab/openlab/issues/79
+      pip install "reno==2.9.2"
     executable: /bin/bash
     chdir: '{{ ansible_user_dir }}/workspace'
   environment: '{{ zuul | zuul_legacy_vars }}'


### PR DESCRIPTION
Version of reno lib is too high in Mitaka devstack deployment.

Closes: theopenlab/openlab#79