### PR TITLE
apt pruge python-six to install reno

### DIFF
--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -24,6 +24,7 @@
       # Because in setuptools>=39, the pkg_resources.parse_version(oslo_utils/versionutils.py) will return an unindexable object
       pip install "setuptools==38.0.0"
       # Fix issue https://github.com/theopenlab/openlab/issues/79
+      apt-get purge --yes python-six python-six-whl python3-six
       pip install "reno==2.9.2"
     executable: /bin/bash
     chdir: '{{ ansible_user_dir }}/workspace'


### PR DESCRIPTION
Related-Bugs: theopenlab/openlab#79