### PR TITLE
Fix packer-1.2.5-functional-orange failing

### DIFF
--- a/playbooks/packer-functional-public-clouds/run.yaml
+++ b/playbooks/packer-functional-public-clouds/run.yaml
@@ -10,7 +10,9 @@
           set -ex
           set -o pipefail
           pip install python-openstackclient
-          flavor=$(openstack flavor list -f value -c ID -c RAM -c VCPUs --sort-column RAM --sort-column VCPUs | head -n 1 | awk '{print $1}')
+          # Using second smallest flavor, because first one might cause testing failed.
+          # See https://github.com/theopenlab/openlab/issues/80
+          flavor=$(openstack flavor list -f value -c ID -c RAM -c VCPUs --sort-column RAM --sort-column VCPUs | awk 'NR==2{print $1}')
           network=$(openstack network show openlab-jobs-net -f value -c id)
           src_img_name=$(openstack image list |grep -Eo "cirros.*0.4.0.*-disk")
           image_name="packer-cirros-openstack-$(date +%s)"


### PR DESCRIPTION
We test packer with flavor t2.micro against Orange cloud,
vm can be launched and active, but guest OS and sshd process
launch slowly, that cause packer check ssh connection timeout.

Closes: theopenlab/openlab#80