### PR TITLE
manila-provisioner job: fixed sourcing openrc params

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-manila-provisioner/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-manila-provisioner/run.yaml
@@ -63,6 +63,9 @@
           '{{ kubectl }}' create clusterrolebinding --user system:serviceaccount:kube-system:shared-informers kube-system-cluster-admin-5 --clusterrole cluster-admin
           '{{ kubectl }}' create clusterrolebinding --user system:kube-controller-manager  kube-system-cluster-admin-6 --clusterrole cluster-admin
 
+          # Sleep to wait for creating serviceaccount default/default complete
+          sleep 5
+
           # OpenStack credentials for manila-provisioner
           '{{ kubectl }}' create secret generic manila-provisioner-secret --from-literal=os-authURL=$OS_AUTH_URL --from-literal=os-domainID=$OS_USER_DOMAIN_ID --from-literal=os-userName=$OS_USERNAME --from-literal=os-password=$OS_PASSWORD --from-literal=os-projectName=$OS_PROJECT_NAME --from-literal=os-region=$OS_REGION_NAME
 

--- a/playbooks/cloud-provider-openstack-acceptance-test-manila-provisioner/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-manila-provisioner/run.yaml
@@ -64,7 +64,7 @@
           '{{ kubectl }}' create clusterrolebinding --user system:kube-controller-manager  kube-system-cluster-admin-6 --clusterrole cluster-admin
 
           # OpenStack credentials for manila-provisioner
-          '{{ kubectl }}' create secret generic manila-provisioner-secret --from-literal=os-authURL=$OS_AUTH_URL --from-literal=os-domainName=$OS_USER_DOMAIN_NAME --from-literal=os-userName=$OS_USERNAME --from-literal=os-password=$OS_PASSWORD --from-literal=os-projectID=$OS_PROJECT_ID --from-literal=os-region=$OS_REGION_NAME
+          '{{ kubectl }}' create secret generic manila-provisioner-secret --from-literal=os-authURL=$OS_AUTH_URL --from-literal=os-domainID=$OS_USER_DOMAIN_ID --from-literal=os-userName=$OS_USERNAME --from-literal=os-password=$OS_PASSWORD --from-literal=os-projectName=$OS_PROJECT_NAME --from-literal=os-region=$OS_REGION_NAME
 
           # Create StorageClass
           cat <<EOF | '{{ kubectl }}' create -f -


### PR DESCRIPTION
This PR:
* fixes sourcing of OpenRC params when creating k8s secret
* adds a sleep to wait for ServiceAccount default/default to complete