### PR TITLE
manila-provisioner job: set manila share type

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-manila-provisioner/post.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-manila-provisioner/post.yaml
@@ -10,6 +10,10 @@
 
           '{{ kubectl }}' delete -f examples/manila-provisioner/cephfs/user-deploy/pod.yaml
           '{{ kubectl }}' delete -f examples/manila-provisioner/cephfs/user-deploy/pvc.yaml
+
+          # wait a bit - we need the storageclass and secrets for deletion
+          sleep 10
+
           '{{ kubectl }}' delete storageclass manila-cephfs-share
           '{{ kubectl }}' delete secret manila-provisioner-secret
         executable: /bin/bash

--- a/playbooks/cloud-provider-openstack-acceptance-test-manila-provisioner/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-manila-provisioner/run.yaml
@@ -78,6 +78,7 @@
           provisioner: manila-provisioner
           parameters:
             osSecretName: manila-provisioner-secret
+            type: cephfstype
             protocol: CEPHFS
             backend: cephfs
           EOF


### PR DESCRIPTION
This PR:
* sets correct manila share type in the `StorageClass`
* adds a `sleep` in between deleting the pvc+pod and sc+secret - just in case