### PR TITLE
Improve the cleanup of docker-machine job

### DIFF
--- a/playbooks/docker-machine-functional-public-clouds/run.yaml
+++ b/playbooks/docker-machine-functional-public-clouds/run.yaml
@@ -77,7 +77,8 @@
             for machine_name in $(docker-machine ls -q); do
                 fip=$(docker-machine ip $machine_name)
                 docker-machine rm -f $machine_name
-                openstack floating ip delete $fip
+                openstack server delete $machine_name || true
+                openstack floating ip delete $fip || true
             done
           args:
             executable: /bin/bash


### PR DESCRIPTION
The "docker-machine rm" may don't remove the VMs successfully, This PR add
a vm deletion step to ensure cleanup.