### PR TITLE
Run cluster-api-provider-openstack-image-build in sigs.k8s.io

### DIFF
--- a/playbooks/cluster-api-provider-openstack-image-build/run.yaml
+++ b/playbooks/cluster-api-provider-openstack-image-build/run.yaml
@@ -1,6 +1,7 @@
 - hosts: all
   roles:
     - config-golang
+    - install-k8s
   become: yes
   tasks:
     - name: Run image build and publish for cluster-api-provider-openstack

--- a/roles/move-k8s-repo-to-k8s-specific-dir/defaults/main.yaml
+++ b/roles/move-k8s-repo-to-k8s-specific-dir/defaults/main.yaml
@@ -1,2 +1,3 @@
 ---
 k8s_repo_src_dir: '{{ ansible_user_dir }}/src/k8s.io/{{ zuul.project.short_name }}'
+k8s_sigs_repo_src_dir: '{{ ansible_user_dir }}/src/sigs.k8s.io/{{ zuul.project.short_name }}'

--- a/roles/move-k8s-repo-to-k8s-specific-dir/tasks/main.yaml
+++ b/roles/move-k8s-repo-to-k8s-specific-dir/tasks/main.yaml
@@ -2,6 +2,13 @@
   shell:
     cmd: |
       set -x
-      mkdir -p $(dirname '{{ k8s_repo_src_dir }}')
-      mv '{{ zuul.project.src_dir }}' '{{ k8s_repo_src_dir }}'
+      ## to path src/sigs.k8s.io/
+      if [ '{{ zuul.project.src_dir }}' =~ 'kubernetes-sigs' ]; then
+          mkdir -p $(dirname '{{ k8s_sigs_repo_src_dir }}')
+          mv '{{ zuul.project.src_dir }}' '{{ k8s_sigs_repo_src_dir }}'
+      ## to path src/k8s.io/
+      else
+          mkdir -p $(dirname '{{ k8s_repo_src_dir }}')
+          mv '{{ zuul.project.src_dir }}' '{{ k8s_repo_src_dir }}'
+      fi
     executable: /bin/bash

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -351,7 +351,8 @@
       Run the image build and publish jobs
     run: playbooks/cluster-api-provider-openstack-image-build/run.yaml
     vars:
-      k8s_cluster_api_provider_os_src_dir: '{{ ansible_user_dir }}/src/k8s.io/cluster-api-provider-openstack'
+      k8s_cluster_api_provider_os_src_dir: '{{ ansible_user_dir }}/src/sigs.k8s.io/cluster-api-provider-openstack'
+    nodeset: ubuntu-xenial
     secrets:
       - dockerhub
 


### PR DESCRIPTION
Job cluster-api-provider-openstack-image-build have to be executed in
sigs.k8s.io directory, so modify role move-k8s-repo-to-k8s-specific-dir
to handle this, and run it on nodeset ubuntu-xenial, add role
install-k8s.

Related-Bugs: theopenlab/openlab#88