### PR TITLE
Add domain_id of public clouds into secrets.yaml

### DIFF
--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -92,6 +92,17 @@
           SPdu3Pdg+//PPWtDf4PRAO38xTkHSNTCRWHYn9JgUXM/2oFxiom1fSr428s5Gv/Nkv7DF
           Axtg+6v6Tv4ox0pJwLj8iy5kVfbSrJFztjuZzcKQ02j4ZOjgD4r5zFTkV8ju28WGcC7wg
           2DPAvdI1rmje4sQpMb43CL9RW6QfVKv7KHcXmO96IWBsBKWHEifzKRoCBcIaIs=
+      domain_id: !encrypted/pkcs1-oaep
+        - SqMKAu7p2/26R6XCOJL68yrtcCR2BamzvRQhlHe6sTrxDVa2ampPaN6ZyH9HDjcMzjpBL
+          e/9rur6zTRdFCbH3XhjTJL1z3P3HHc1af8d1HZuobb0LsbmUyDOqa4NIPY+jIHokWFE7A
+          xPytBDLW7s6m51c8aKCNM5JHczeiQ/qo+//l4ieUD40PYI7hqfrz8V/Z3snYifhFXZ5yg
+          /svN36+o77DIYKh79IrEwnadeMdahzSV3bY+IvK9x5cP4XwO0Uj/zLjhk4Fiu73TpwANz
+          CxsKzjYkLDAD2v+gzp2TOI+9pD3IjFuOU4vjWfjeXSqV1E5Adq4Whd6I5fMWFivL2/3py
+          RAV40CI/r8S83T6fYnXCS4zPnwLYJsSf7z1ivjjVbWqhJmV0n9COAV0GmglzXcr6+2X3z
+          csAS7vu/7lZLf/8zvVN8emWfNL8jnKddQL39JwBPRQsEKyyz9sd0C4dEAiS+xP+JtmN28
+          KcW7/Yr7mNfKrfCJug8EO11eyZwzbpblEcZtJn8AU/wIskerCL8vgznPwlwGOI88Cywf1
+          pHAEs5w7TfFJXPy9JTsVPvvZtGhikizX3ld3FbnOMK7+WtMIb3xJ7TXgbufkikyP0gMgz
+          Xg30mLsQ+1R0EiPgVJnPw7dmyJUAF2YnkRB1NrW68w4p4LqBvSe8nzTvIjNWD8=
       ## sa-brazil-1
       project_name: !encrypted/pkcs1-oaep
         - NFl7C6BgKVDrM9zhQBQf/gsy0EAS2EefiP0BhmMbfbSZj3qkmDH8ApgIgdOwBk3w3S92P
@@ -165,6 +176,17 @@
           PutBJvcHkROS5R/5kJ93K2BGjGL4gdAlXRokVSFCef0AFAzx48Ov0bFewv1IqpE6yG8B3
           +3oxrQDGaP6FO/8o5GBopxjPVFu0MbgYgoOn/bbK0/wQ1ohHvFSrraejNF+n6Frq4q27P
           IVjb0MZTN5z/MDZbjBCv+e0lhpZYCuLtzCTrVsvG/o988Euj00xznwgDUqXbwU=
+      domain_id: !encrypted/pkcs1-oaep
+        - iVnJL9oCA/jAZg53/Cnohx/yOwzI3F+JjYrPJsmlVYHMhk93PLSxAxz3CqIhevqGR611s
+          EQnuQUZAFKTPsB8CnRnsu7wSmemG4LtNpWVRIaYLJjvYjZHn15avYZsRLa6hqMQA0A1AQ
+          EiwvY9e6NuBSP7fFMJmj6pFVLfjpOy/fRR2SooPPxeqmpCIPtoRGH/AoVNf1GDBL1vHQj
+          UthhBVvCpgZ3319nBJTmKeugghANWDE/Li+vy6IQ0Tusm4LXGq37MMuA//2JdX7K3mlnF
+          Kv7QHoOMk55fXbwoHGfUcg7z92xNdYWrezsIhUVu94rZuU1a0alZCCIrH/b35ziylJToI
+          wnRzFxpmbsbF3XBy8vt30zEK/FEl8AtI8MeMtQRI7SMNm1I0egk9Fyekqf8knkYlJ99qQ
+          d7TiblvFm4HK1POCYlNonovhCYwbCC+nvMrhcX8achfj4JMXOS7Md80UHzWSnbKmeYDjO
+          tpH+/ZiC83kREqwkdM80/cBm+QissbpUdvOb4zrFCN3AlYRpjwnWH9UpofrYRFr/FYXnF
+          C6LtXxNecUmfNZE6z3f1Zaihyb/OCQUaMAXa0W2WCLPYP2a/dR9UiB0QOPKfT8lD1zdm8
+          Dq0m1oFnSZRNmYT3Ahpl1wT6N2aJm+HMceENqn91oa42O+/ZVjkWihAEUS3LnU=
       project_name: !encrypted/pkcs1-oaep
         - AfxcI8SMlQ7+1SaRYBc0fRYvxkkqCXn46bzif8EhgGdkp6aBiW0HPGJo9lC24PvUAQ3G9
           KzK1Qz5CVaMysvns/fof09iN0TnUt51M2NiU48jeHM7RUPLW/nP7hFSFtEvmBanA66Xww
@@ -270,6 +292,17 @@
           AuEouEVKQSMPVrJPGrSbyfOywndrsZYYqQdbcSOzo4oNZYY8AJRJ/yKBn0HdxUa7agHDY
           4S5cM4kl0ga27DUu4VC/GeUn85sYB/Z726kXRUfHFN93WfT9pZftaRxcSlOIi101pVKOy
           bWmivIRFb7sCwMcceIN/mav97QvND49WVQbzidu9Rt1xEPujikeRgThU8kT6oI=
+      domain_id: !encrypted/pkcs1-oaep
+        - QHu0zJGi2tRT6uEfu7itEvNwhtXoPL6UVfWu1lcLkdKIiyg1Zaud51vOZSScpNA3Vle6G
+          P4rZzcs2UKX+E+CoXfnFaxR01zP+tylocnq269HknJDKeRKwXCEPOiLy/Jsi/YzAt4kUB
+          dCs86ZcR5ibDnR4m2CHcmY5aeMoz3vYNV/HcD13gnYI8GPcndV4CCgiUWSlejigT/4J+n
+          kD/5zxXOiKAwpNapwUKpiLyz9fJf2RaJA2VY5RPyspF72tsFcuPZz/lVJCAc6W9qYZgel
+          QAH2LhxuFyGFtSSL2TniULgZlSM+Dpf7qoaPcQrzjhdOig1sNjqOIRMjYQsdz1n+SmSOw
+          s47RR4EyNdCop5t5NSDGBUULiY5nK+cKNSrjaGEzIX/DcYuiUsqWhMRZ0JUWC0lgs1gRx
+          Sap4k/8LYk7jugPvCOJpZ/T6VJYGr8lPWlOPNByNDSFw8nqcnz3Twwlf78snXDGwPwh8+
+          GLDQNA4wCpjdyz9YLHGJgstggMCA/Lho/ikArlal6CymUZOw4fqos0Wa4FwnYOrzqOyEu
+          m6FGd7cQOBq8Taox6IAvoPUAfeCa2qV5IMKF3CEDAHEiZZj/yacaW1b9cYhCuhVG/o/A4
+          SmNE7lm31f1wKPye6QNrfR8Zt3UWow/ldQh2MDH2AgjBAp3V2uBpa0fu2nnhHk=
       project_name: !encrypted/pkcs1-oaep
         - PxzHeWiAqUdpMS25ZSyHYxFSOyWqpB+3p11Qh6e0vs/jExsJuSazcRiqxY3zpOKsQm7YN
           fhEDpzM2sDSdmlePYHvux4P7Ssi/qRnpm2CHaRLqC4mfpUf4DyZh7Rkm97J3toX0EdFbm
@@ -397,6 +430,17 @@
           SHFTYoNVFoRHBFTuAo9WXwZVNT3GSqwbiqD8YQtIiY5Hf/ZW4/XAGzejSoRiFnioO5nfs
           j83K6rZ8CcmKiyP7W2Id2MvYP7rxPXXUHQWnSkx27DjOqYQ4UgAEvzUGm/ieYcsf6HATO
           gYn+N1hNIf6rh0HZvc60unrsHQ8HjE6yqtBaNPvnUWPOedcIzW2ztZmgHRtBqM=
+      domain_id: !encrypted/pkcs1-oaep
+        - CNR/7YvxgtRtJzE/q6wOjU/Ubh4H/ISgGAqEk/cTNbhm49UVqiunfJn9SN9VHzOJIDG9l
+          lqy03/1LhoJ7h3YdVd8qtJkYiX8TUnlAmI+AmH0oM7+25Vgv0mqeRgqd+AIKk8v+kKBnp
+          mTAd5IV5GrUFDrEgHUmRN6NZbOPeeVt/fH8JuISXu5G4Z5tK2uZms3DjJGz+1MzSkA9ED
+          yGh72zfUvO1qTDkrSojRbHIuknsfDLP/2feRi0aa2H+TJaLfPV5+su+INF1eVAV7Gm0X5
+          fzwfYQHsX+SJTeqCQHvFiFNuDkaWVn8jfkajMN86UWmxfYwr8AM9hHQCLuofp6tqmc6Ya
+          gdH5OcuZpEAuDasKusJH1xUlJ3G4Et802nwdB7D2rOApCMxS5KrgsqKAq81PsWqAqZJZS
+          bKNwvOdTRr9BkHo12ZjcqQxYiFzSsc09rlvFrlwSyWmkdu0FSWgRZYnPo+ZSMsda1VsDW
+          KET5PnnaaG+oFmjpNDIwxPFF1GRR3mbxzoObYQKCzXWp5ZbwZ8pT1I0az8l/QoYtADvMF
+          dkEf6JSg2JZs2FI2BOEuA6X6G1riQeNO6E5RThcZrAFQUPGYIPhD5HJiiWLZOIXuHi0aG
+          RAhwxPOrjsOpXLcsFxCz5QrvgnpgmdYpJmW1pYTBt8Z0bSbq8HH4DOnhTurLUc=
       project_name: !encrypted/pkcs1-oaep
         - InqDX+lCzksBLhQRGlHz5pc7+6pleongMpkkoBRSqDCXUmsZgch0kXK26TfIe1YCaR5bl
           G1MU3dZfm/KczqNqejSznBn7iElznNvykyizKKcOESDnhCm4mOy5kx3fhLiGW55KEc9Hi


### PR DESCRIPTION
We need domain_id of public clouds to run ManageIQ integration tests.

Related-Bugs: theopenlab/openlab#81