### PR TITLE
Enable neutron-trunk when extension enabled

### DIFF
--- a/playbooks/terraform-provider-openstack-acceptance-test/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test/run.yaml
@@ -7,6 +7,7 @@
       enable_services:
         - 'manila'
         - 'designate'
+        - 'neutron-ext'
     - install-devstack
   tasks:
     - name: Run acceptance tests with terraform-provider-openstack

--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -39,7 +39,7 @@
   when:
     - '"heat" in enable_services'
 
-# Use neutron-* services to replace q-* services except Mitaka
+# Use neutron-* services to replace q-* services except Mitaka, Newton, Ocata and Pike
 - name: enable neutron services by new services names
   shell:
     cmd: |
@@ -58,6 +58,23 @@
     - '"fwaas-v1" not in enable_services'
     - '"fwaas-v2" not in enable_services'
 
+- name: enable neutron non-default extension by name neutron-ext
+  shell:
+    cmd: |
+      set -e
+      set -x
+      # From Queens
+      insert_service='enable_service neutron-trunk'
+      if [[ "{{ global_env.OS_BRANCH }}" == "stable/mitaka" || \
+            "{{ global_env.OS_BRANCH }}" == "stable/newton" || \
+            "{{ global_env.OS_BRANCH }}" == "stable/ocata" || \
+            "{{ global_env.OS_BRANCH }}" == "stable/pike" ]]; then
+          insert_service='enable_service q-trunk'
+      fi
+      echo ${insert_service} >> /tmp/dg-local.conf
+    executable: /bin/bash
+  when:
+  - '"neutron-ext" in enable_services'
 
 # Populate local conf with specific branch
 - name: create devstack local conf on stable/mitaka branch


### PR DESCRIPTION
Gophercloud and terraform-provider-openstack need to test
neutron trunk feature, but trunk extension is not enabled
by default in devstack, so we add a flat "neutron-ext" to
enable "neutron-trunk" or others extenstions.

Related-Bugs: theopenlab/openlab#92
Related-Bugs: theopenlab/openlab-zuul-jobs#341