### PR TITLE
Fix both OS_DOMAIN_ID and OS_DOMAIN_NAME existed issue

### DIFF
--- a/playbooks/docker-machine-functional-public-clouds/run.yaml
+++ b/playbooks/docker-machine-functional-public-clouds/run.yaml
@@ -10,6 +10,7 @@
           shell:
             cmd: |
               set -ex
+              unset OS_DOMAIN_ID
               pip install python-openstackclient
               git clone https://github.com/sstephenson/bats.git
               pushd bats

--- a/playbooks/packer-functional-public-clouds/run.yaml
+++ b/playbooks/packer-functional-public-clouds/run.yaml
@@ -9,6 +9,7 @@
         cmd: |
           set -ex
           set -o pipefail
+          unset OS_DOMAIN_ID
           pip install python-openstackclient
           # Using second smallest flavor, because first one might cause testing failed.
           # See https://github.com/theopenlab/openlab/issues/80


### PR DESCRIPTION
PR theopenlab/openlab#345 export OS_DOMAIN_ID and OS_DOMAIN_NAME
into envrionment variables, but packer and docker-machine can not
handle both them existed. This patch address the issue.

Closes: theopenlab/openlab#94