### PR TITLE
Fix manageiq-providers-openstack-test-devstack issues

### DIFF
--- a/roles/clean-devstack-default-resources/tasks/main.yaml
+++ b/roles/clean-devstack-default-resources/tasks/main.yaml
@@ -17,5 +17,14 @@
       openstack subnet delete public-subnet
       openstack subnet delete private-subnet
       openstack network delete private public
-      openstack flavor delete `openstack flavor list -f value -c ID --sort-column ID | tail -n +6` || true
+      flavor_white_list="'m1.tiny' 'm1.small' 'm1.medium' 'm1.large' 'm1.xlarge'"
+      for flavor_name in `openstack flavor list -f value -c Name`
+      do
+          if [[ "${flavor_white_list}" =~ "${flavor_name}" ]]; then
+              echo "keep flavor ${flavor_name}"
+          else
+              echo "delete flavor ${flavor_name}"
+              openstack flavor delete "${flavor_name}"
+          fi
+      done
     executable: /bin/bash


### PR DESCRIPTION
- openstackclient don't support --sort-column option in M, N, O, P,
  so use more simple command to handle flavor.
- sync with upstream of manageiq-providers-openstack to address
  bin/setup issue.

Closes: theopenlab/openlab#95