### PR TITLE
Fix debian mirror unavailable issue

### DIFF
--- a/playbooks/manageiq-providers-openstack-test-devstack/run.yaml
+++ b/playbooks/manageiq-providers-openstack-test-devstack/run.yaml
@@ -46,8 +46,8 @@
           su postgres -c "psql -c \"CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'\""
 
           # Ubuntu fix for failing Bundler
-          wget -t 10 -T 2 http://ftp.cz.debian.org/debian/pool/main/o/openssl1.0/libssl1.0-dev_1.0.2o-1_amd64.deb
-          wget -t 10 -T 2 http://ftp.cz.debian.org/debian/pool/main/o/openssl1.0/libssl1.0.2_1.0.2o-1_amd64.deb
+          wget -t 10 -T 2 http://ftp.debian.org/debian/pool/main/o/openssl1.0/libssl1.0-dev_1.0.2o-1_amd64.deb
+          wget -t 10 -T 2 http://ftp.debian.org/debian/pool/main/o/openssl1.0/libssl1.0.2_1.0.2o-1_amd64.deb
           apt remove -y libssl-dev
           dpkg -i libssl1.0-dev_1.0.2o-1_amd64.deb libssl1.0.2_1.0.2o-1_amd64.deb
 

--- a/playbooks/manageiq-providers-openstack-test-public-clouds/run.yaml
+++ b/playbooks/manageiq-providers-openstack-test-public-clouds/run.yaml
@@ -39,8 +39,8 @@
           su postgres -c "psql -c \"CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'\""
 
           # Ubuntu fix for failing Bundler
-          wget http://ftp.cz.debian.org/debian/pool/main/o/openssl1.0/libssl1.0-dev_1.0.2o-1_amd64.deb
-          wget http://ftp.cz.debian.org/debian/pool/main/o/openssl1.0/libssl1.0.2_1.0.2o-1_amd64.deb
+          wget http://ftp.debian.org/debian/pool/main/o/openssl1.0/libssl1.0-dev_1.0.2o-1_amd64.deb
+          wget http://ftp.debian.org/debian/pool/main/o/openssl1.0/libssl1.0.2_1.0.2o-1_amd64.deb
           apt remove -y libssl-dev
           dpkg -i libssl1.0-dev_1.0.2o-1_amd64.deb libssl1.0.2_1.0.2o-1_amd64.deb
 


### PR DESCRIPTION
Sometimes ftp.cz.debian.org mirror may be unavailable, we
have faced several times in this week, try to use main site
ftp.debian.org to instead.

Closes: theopenlab/openlab#96
Related-Bugs: theopenlab/openlab#81