### PR TITLE
Enable SSL to test manageiq-providers-openstack-test-public-clouds

### DIFF
--- a/playbooks/manageiq-providers-openstack-test-public-clouds/run.yaml
+++ b/playbooks/manageiq-providers-openstack-test-public-clouds/run.yaml
@@ -65,6 +65,8 @@
           sed -i "/setup_ems/ s|admin|$OS_USERNAME|" spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_spec.rb
           sed -i "/setup_ems/ s|5000|433|" spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_spec.rb
           sed -i "/setup_ems/ s|default|$OS_DOMAIN_ID|" spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_spec.rb
+          #NOTES: public cloud apply SSL for API, so enable it to test
+          sed -i "/security_protocol/ s|no_ssl|ssl|" spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_helpers.rb
           set -x
 
           rm spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_havana_errors_spec.rb


### PR DESCRIPTION
public cloud apply SSL connection in API, so we should use SSL way to test integration.

Closes: theopenlab/openlab#97
Related-Bugs: theopenlab/openlab#81