### PR TITLE
Enable legacy endpoint format for docker-machine

### DIFF
--- a/playbooks/docker-machine-functional-devstack/run.yaml
+++ b/playbooks/docker-machine-functional-devstack/run.yaml
@@ -1,5 +1,8 @@
 - hosts: all
   become: yes
+  vars:
+    #NOTES: docker-machine don't support OpenStack version discovery, so enable legacy endpoint format.
+    DISABLE_HTTPD_MOD_WSGI: true
   roles:
     - clone-devstack-gate-to-workspace
     - create-devstack-local-conf

--- a/playbooks/manageiq-providers-openstack-test-devstack/run.yaml
+++ b/playbooks/manageiq-providers-openstack-test-devstack/run.yaml
@@ -1,6 +1,7 @@
 - hosts: all
   become: yes
   vars:
+    #NOTES: manageiq-providers-openstack don't support OpenStack version discovery, so enable legacy endpoint format.
     DISABLE_HTTPD_MOD_WSGI: true
   roles:
     - clone-devstack-gate-to-workspace


### PR DESCRIPTION
docker-machine don't support OpenStack version discovery,
so enable legacy endpoint format in devstack related jobs.

Related-Bugs: theopenlab/openlab#74