### PR TITLE
Add document links into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ This repo contains a set of Ansible playbooks which are used by the OpenLab CI
 system. Any 3rd project want to integrate with the OpenLab CI, need to add
 jobs definitions into this repo firstly.
 
+If this is first time you come to OpenLab, please start with OpenLab
+[Getting Started](https://docs.openlabtesting.org/publications/).
+
 Jobs naming notations
 ---------------------
 To unify the jobs name format, we have the following naming notations:
@@ -26,8 +29,8 @@ More information
 ----------------
 Web page about OpenLab:
 
-    http://openlabtesting.org/
+> http://openlabtesting.org/
 
-Documentation about how to integrate OpenLab CI:
+Development Guide:
 
-    https://docs.openlabtesting.org/publications/contributors/connect-to-openlab
+> https://docs.openlabtesting.org/publications/contributors/development-guide


### PR DESCRIPTION
- Add `Getting Started`
- Add `Development Guide`

Related-Bug: theopenlab/openlab#100