### PR TITLE
Clean the legacy Go projects path compatibility workarounds

### DIFF
--- a/playbooks/terraform-provider-flexibleengine-acceptance-test-orange/run.yaml
+++ b/playbooks/terraform-provider-flexibleengine-acceptance-test-orange/run.yaml
@@ -44,13 +44,6 @@
           set -x
 
           # Run acc test
-          if [[ ! -d $GOPATH/src/github.com/Karajan-project/terraform-provider-flexibleengine/ && -d $GOPATH/src/github.com/animationzl/terraform-provider-flexibleengine ]]; then
-              echo "Warning: this is a temporary workaround because this job is not triggered from official git repo."
-              mkdir -p $GOPATH/src/github.com/Karajan-project/
-              cp -r $GOPATH/src/github.com/animationzl/terraform-provider-flexibleengine  $GOPATH/src/github.com/Karajan-project/
-              cd $GOPATH/src/github.com/Karajan-project/terraform-provider-flexibleengine
-          fi
-
           make testacc 2>&1 | tee $TEST_RESULTS_TXT
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'

--- a/playbooks/terraform-provider-openstack-acceptance-test-designate/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-designate/run.yaml
@@ -36,15 +36,6 @@
           echo export OS_SHARE_NETWORK_ID=foobar >> openrc
           source openrc demo demo
           popd
-
-          # Run acc test
-          if [[ ! -d $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack/ && -d $GOPATH/src/github.com/theopenlab/terraform-provider-openstack ]]; then
-              echo "Warning: this is a temporary workaround because this job is not triggered from official git repo."
-              mkdir -p $GOPATH/src/github.com/terraform-providers/
-              cp -r $GOPATH/src/github.com/theopenlab/terraform-provider-openstack  $GOPATH/src/github.com/terraform-providers/
-              cd $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack
-          fi
-
           # Run the DNS test 100 testcases at a time
           export OS_DNS_ENVIRONMENT=1 # for Designate tests
           testcases=`go test ./openstack/ -v -list 'Acc'`

--- a/playbooks/terraform-provider-openstack-acceptance-test-fwaas/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-fwaas/run.yaml
@@ -36,14 +36,6 @@
           source openrc demo demo
           popd
 
-          # Run acc test
-          if [[ ! -d $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack/ && -d $GOPATH/src/github.com/theopenlab/terraform-provider-openstack ]]; then
-              echo "Warning: this is a temporary workaround because this job is not triggered from official git repo."
-              mkdir -p $GOPATH/src/github.com/terraform-providers/
-              cp -r $GOPATH/src/github.com/theopenlab/terraform-provider-openstack  $GOPATH/src/github.com/terraform-providers/
-              cd $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack
-          fi
-
           # Run the FWaaS test 100 testcases at a time
           export OS_FW_ENVIRONMENT=1 # for FWaaS tests
           testcases=`go test ./openstack/ -v -list 'Acc'`

--- a/playbooks/terraform-provider-openstack-acceptance-test-lbaas/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-lbaas/run.yaml
@@ -37,14 +37,6 @@
           source openrc demo demo
           popd
 
-          # Run acc test
-          if [[ ! -d $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack/ && -d $GOPATH/src/github.com/theopenlab/terraform-provider-openstack ]]; then
-              echo "Warning: this is a temporary workaround because this job is not triggered from official git repo."
-              mkdir -p $GOPATH/src/github.com/terraform-providers/
-              cp -r $GOPATH/src/github.com/theopenlab/terraform-provider-openstack  $GOPATH/src/github.com/terraform-providers/
-              cd $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack
-          fi
-
           # Run the LB test 100 testcases at a time
           export OS_LB_ENVIRONMENT=1 # for LBaaS tests
           testcases=`go test ./openstack/ -v -list 'Acc'`

--- a/playbooks/terraform-provider-openstack-acceptance-test-trove/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-trove/run.yaml
@@ -76,13 +76,6 @@
           # Fix iptables rules that prevent amqp connections from the devstack box to the guests
           iptables -D openstack-INPUT -j REJECT --reject-with icmp-host-prohibited || true
 
-          if [[ ! -d $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack/ && -d $GOPATH/src/github.com/theopenlab/terraform-provider-openstack ]]; then
-              echo "Warning: this is a temporary workaround because this job is not triggered from official git repo."
-              mkdir -p $GOPATH/src/github.com/terraform-providers/
-              cp -r $GOPATH/src/github.com/theopenlab/terraform-provider-openstack  $GOPATH/src/github.com/terraform-providers/
-              cd $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack
-          fi
-
           # Run the DNS test 100 testcases at a time
           export OS_DB_ENVIRONMENT=1
 

--- a/playbooks/terraform-provider-openstack-acceptance-test/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test/run.yaml
@@ -39,14 +39,6 @@
           source openrc demo demo
           popd
 
-          # Run acc test
-          if [[ ! -d $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack/ && -d $GOPATH/src/github.com/theopenlab/terraform-provider-openstack ]]; then
-              echo "Warning: this is a temporary workaround because this job is not triggered from official git repo."
-              mkdir -p $GOPATH/src/github.com/terraform-providers/
-              cp -r $GOPATH/src/github.com/theopenlab/terraform-provider-openstack  $GOPATH/src/github.com/terraform-providers/
-              cd $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack
-          fi
-
           # Run except the DNS/FW/LB test 100 testcases at a time
           export OS_SWIFT_ENVIRONMENT=1 # for Swift tests
           testcases=`go test ./openstack/ -v -list 'Acc'`

--- a/playbooks/terraform-provider-openstack-unittest/run.yaml
+++ b/playbooks/terraform-provider-openstack-unittest/run.yaml
@@ -11,13 +11,6 @@
           set -x
 
           # Run unit test
-          if [[ ! -d $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack/ && -d $GOPATH/src/github.com/theopenlab/terraform-provider-openstack ]]; then
-              echo "Warning: this is a temporary workaround because this job is not triggered from official git repo."
-              mkdir -p $GOPATH/src/github.com/terraform-providers/
-              cp -r $GOPATH/src/github.com/theopenlab/terraform-provider-openstack  $GOPATH/src/github.com/terraform-providers/
-              cd $GOPATH/src/github.com/terraform-providers/terraform-provider-openstack
-          fi
-
           make test TESTARGS='-v' 2>&1 | tee $TEST_RESULTS_TXT
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'

--- a/playbooks/terraform-provider-telefonicaopencloud-acceptance-test-telefonica/run.yaml
+++ b/playbooks/terraform-provider-telefonicaopencloud-acceptance-test-telefonica/run.yaml
@@ -39,14 +39,6 @@
           ret=0
           set -o pipefail
           set -x
-
-          if [[ ! -d $GOPATH/src/github.com/huawei-clouds/terraform-provider-telefonicaopencloud/ && -d $GOPATH/src/github.com/liu-sheng/terraform-provider-telefonicaopencloud ]]; then
-              echo "Warning: this is a temporary workaround because this job is not triggered from official git repo."
-              mkdir -p $GOPATH/src/github.com/huawei-clouds/
-              cp -r $GOPATH/src/github.com/liu-sheng/terraform-provider-telefonicaopencloud  $GOPATH/src/github.com/huawei-clouds/
-              cd $GOPATH/src/github.com/huawei-clouds/terraform-provider-telefonicaopencloud/
-          fi
-
           # Run except the DNS/FW/LB test 100 testcases at a time
           testcases=`go test github.com/huawei-clouds/terraform-provider-telefonicaopencloud/telefonicaopencloud/ -v -list 'Acc'`
           testcases=`echo "$testcases" | sed '$d' | grep -v -e FW -e LB`


### PR DESCRIPTION
For these jobs, we don't need to trigger jobs from the forked repos any
more.

Closes: theopenlab/openlab#123
Related-Bugs: theopenlab/openlab#100