### PR TITLE
Add jobs to integrate terraform-provider-openstack with generic clouds

### DIFF
--- a/playbooks/terraform-provider-openstack-acceptance-test-huaweicloud/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-huaweicloud/run.yaml
@@ -1,0 +1,41 @@
+- hosts: all
+  become: yes
+  roles:
+    - config-golang
+    - role: export-cloud-openrc
+      vars:
+        cloud_name: 'huaweicloud'
+  tasks:
+    - name: Run acceptance tests with terraform-provider-openstack against huawei public cloud
+      shell:
+        cmd: |
+          apt-get install python-pip -y
+          pip install -U python-openstackclient
+
+          openstack flavor create m1.acctest --id 99 --ram 512 --disk 5 --vcpu 1 --ephemeral 10
+          openstack flavor create m1.resize --id 98 --ram 512 --disk 6 --vcpu 1 --ephemeral 10
+          unset OS_DOMAIN_ID
+          export OS_SHARE_NETWORK_ID="foobar"
+          export OS_FLAVOR_ID_RESIZE="s2.medium.2"
+          export OS_FLAVOR_ID="s2.small.1"
+          export OS_POOL_NAME="admin_external_net"
+          export OS_EXTGW_ID="$(openstack network show $OS_POOL_NAME -f value -c id)"
+          export OS_IMAGE_NAME="cirros-0.4.0-x86_64-disk"
+          export OS_IMAGE_ID="$(openstack image show $OS_IMAGE_NAME -f value -c id)"
+
+          # we pre-create 'openlab-jobs-net', 'openlab-jobs-subnet' and 'openlab-jobs-vpc' for ci jobs
+          export OS_NETWORK_NAME="openlab-jobs-net"
+          export OS_NETWORK_ID="ad2c3a5b-8885-420f-90ac-b2241cfe54c5"
+          export OS_VPC_ID="d9271807-b320-4609-aac9-f7f5b2d85830"
+
+          set -e
+          set -o pipefail
+          set -x
+
+          # Run except the DNS/FW/LB test 100 testcases at a time
+          testcases=`go test ./openstack/ -v -list 'Acc'`
+          testcases=`echo "$testcases" | sed '$d' | grep -v -e FW -e LB`
+          echo "$testcases" | xargs -t -n100 sh -c 'TF_LOG=DEBUG TF_ACC=1 go test ./openstack -v -timeout 120m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
+      environment: '{{ global_env }}'

--- a/playbooks/terraform-provider-openstack-acceptance-test-opentelekomcloud/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-opentelekomcloud/run.yaml
@@ -1,0 +1,42 @@
+- hosts: all
+  become: yes
+  roles:
+    - config-golang
+    - role: export-cloud-openrc
+      vars:
+        cloud_name: 'opentelekomcloud'
+  tasks:
+    - name: Run acceptance tests with terraform-provider-openstack against opentelekom public cloud
+      shell:
+        cmd: |
+          apt-get install python-pip -y
+          pip install -U python-openstackclient
+
+          set -o pipefail
+          set -x
+          openstack flavor create m1.acctest --id 99 --ram 512 --disk 5 --vcpu 1 --ephemeral 10
+          openstack flavor create m1.resize --id 98 --ram 512 --disk 6 --vcpu 1 --ephemeral 10
+          unset OS_DOMAIN_ID
+          export OS_SHARE_NETWORK_ID="foobar"
+          export OS_FLAVOR_ID_RESIZE='computev2-1'
+          export OS_FLAVOR_ID='computev1-1'
+          export OS_POOL_NAME="admin_external_net"
+          export OS_EXTGW_ID=`openstack network list -f value |grep admin_external_net | awk -F ' ' '{print $1}'`
+          export OS_IMAGE_NAME="cirros-0.4.0-x86_64-disk"
+          export OS_IMAGE_ID="$(openstack image show $OS_IMAGE_NAME -f value -c id)"
+
+          # we pre-create 'openlab-jobs-net', 'openlab-jobs-subnet' and 'openlab-jobs-vpc' for ci jobs
+          export OS_NETWORK_NAME="openlab-jobs-net"
+          export OS_NETWORK_ID="205c893d-7363-4fa3-b2a0-5f36387e8a51"
+          export OS_VPC_ID="516afade-9fb1-4dd0-95df-8414b2ac8c27"
+
+          export OS_SWIFT_ENVIRONMENT=1
+
+          # Run except the DNS/FW/LB test 100 testcases at a time
+          testcases=`go test ./openstack/ -v -list 'Acc'`
+          testcases=`echo "$testcases" | sed '$d' | grep -v -e FW -e LB`
+          echo "$testcases" | xargs -t -n100 sh -c 'TF_LOG=DEBUG TF_ACC=1 go test ./openstack -v -timeout 120m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
+
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
+      environment: '{{ global_env }}'

--- a/playbooks/terraform-provider-openstack-acceptance-test-orange/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-orange/run.yaml
@@ -1,0 +1,41 @@
+- hosts: all
+  become: yes
+  roles:
+    - config-golang
+    - role: export-cloud-openrc
+      vars:
+        cloud_name: 'orange'
+  tasks:
+    - name: Run acceptance tests with terraform-provider-openstack against orange public cloud
+      shell:
+        cmd: |
+          apt-get install python-pip -y
+          pip install -U python-openstackclient
+
+          openstack flavor create m1.acctest --id 99 --ram 512 --disk 5 --vcpu 1 --ephemeral 10
+          openstack flavor create m1.resize --id 98 --ram 512 --disk 6 --vcpu 1 --ephemeral 10
+          unset OS_DOMAIN_ID
+          export OS_SHARE_NETWORK_ID="foobar"
+          export OS_FLAVOR_ID_RESIZE="t2.small"
+          export OS_FLAVOR_ID="t2.micro"
+          export OS_POOL_NAME="admin_external_net"
+          export OS_EXTGW_ID="$(openstack network show $OS_POOL_NAME -f value -c id)"
+          export OS_IMAGE_NAME="cirros-0.4.0-x86_64-disk"
+          export OS_IMAGE_ID="$(openstack image show $OS_IMAGE_NAME -f value -c id)"
+
+          # we pre-create 'openlab-jobs-net', 'openlab-jobs-subnet' and 'openlab-jobs-vpc' for ci jobs
+          export OS_NETWORK_NAME="openlab-jobs-net"
+          export OS_NETWORK_ID="3a4b46c4-dabf-47f8-8b8d-bdc872630122"
+          export OS_VPC_ID="7436f45a-b08a-4648-9f63-0bcad841c536"
+
+          set -e
+          set -o pipefail
+          set -x
+
+          # Run except the DNS/FW/LB test 100 testcases at a time
+          testcases=`go test ./openstack/ -v -list 'Acc'`
+          testcases=`echo "$testcases" | sed '$d' | grep -v -e FW -e LB`
+          echo "$testcases" | xargs -t -n100 sh -c 'TF_LOG=DEBUG TF_ACC=1 go test ./openstack -v -timeout 120m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
+      environment: '{{ global_env }}'

--- a/playbooks/terraform-provider-openstack-acceptance-test-telefonica/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-telefonica/run.yaml
@@ -1,0 +1,44 @@
+- hosts: all
+  become: yes
+  roles:
+    - config-golang
+    - role: export-cloud-openrc
+      vars:
+        cloud_name: 'telefonica'
+  tasks:
+    - name: Run acceptance tests with terraform-provider-openstack against telefonica public cloud
+      shell:
+        cmd: |
+          apt-get install python-pip -y
+          pip install -U python-openstackclient
+
+          openstack flavor create m1.acctest --id 99 --ram 512 --disk 5 --vcpu 1 --ephemeral 10
+          openstack flavor create m1.resize --id 98 --ram 512 --disk 6 --vcpu 1 --ephemeral 10
+          unset OS_DOMAIN_ID
+          export OS_SHARE_NETWORK_ID="foobar"
+          export OS_FLAVOR_ID_RESIZE='c2.medium'
+          export OS_FLAVOR_ID='c1.medium'
+          export OS_POOL_NAME="admin_external_net"
+          export OS_EXTGW_ID="$(openstack network show $OS_POOL_NAME -f value -c id)"
+          export OS_IMAGE_NAME="Ubuntu 16.04 Server 64bit"
+          export OS_IMAGE_ID="$(openstack image show $OS_IMAGE_NAME -f value -c id)"
+
+          # we pre-create 'openlab-jobs-net', 'openlab-jobs-subnet' and 'openlab-jobs-vpc' for ci jobs
+          export OS_NETWORK_NAME="openlab-jobs-net"
+          export OS_NETWORK_ID="391a966d-8ee7-422f-a200-641e1351ace4"
+          export OS_VPC_ID="25f2e2b2-6a2b-44d8-863a-52acdb1e266c"
+
+          export OS_SWIFT_ENVIRONMENT=1
+
+          # set -e
+          ret=0
+          set -o pipefail
+          set -x
+
+          # Run except the DNS/FW/LB test 100 testcases at a time
+          testcases=`go test ./openstack/ -v -list 'Acc'`
+          testcases=`echo "$testcases" | sed '$d' | grep -v -e FW -e LB`
+          echo "$testcases" | xargs -t -n100 sh -c 'TF_LOG=DEBUG TF_ACC=1 go test ./openstack -v -timeout 120m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
+      environment: '{{ global_env }}'

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -144,6 +144,46 @@
       Run terraform provider openstack fwaas acceptance test on master branch
     run: playbooks/terraform-provider-openstack-acceptance-test-fwaas/run.yaml
 
+# terraform-provider-openstack acceptance tests with Telefonica cloud
+- job:
+    name: terraform-provider-openstack-acceptance-test-telefonica
+    parent: golang-test
+    description: |
+      Run acceptance tests of terraform-provider-openstack repo against telefonica cloud
+    run: playbooks/terraform-provider-openstack-acceptance-test-telefonica/run.yaml
+    secrets:
+      - telefonica_credentials
+
+# terraform-provider-openstack acceptance tests with Open Telekom cloud
+- job:
+    name: terraform-provider-openstack-acceptance-test-opentelekomcloud
+    parent: golang-test
+    description: |
+      Run acceptance tests of terraform-provider-openstack repo against opentelekomcloud
+    run: playbooks/terraform-provider-openstack-acceptance-test-opentelekomcloud/run.yaml
+    secrets:
+      - opentelekomcloud_credentials
+
+# terraform-provider-openstack acceptance tests with orange cloud
+- job:
+    name: terraform-provider-openstack-acceptance-test-orange
+    parent: golang-test
+    description: |
+      Run acceptance tests of terraform-provider-openstack repo against orange cloud
+    run: playbooks/terraform-provider-openstack-acceptance-test-orange/run.yaml
+    secrets:
+      - orange_credentials
+
+# terraform-provider-openstack acceptance tests with huawei cloud
+- job:
+    name: terraform-provider-openstack-acceptance-test-huaweicloud
+    parent: golang-test
+    description: |
+      Run acceptance tests of terraform-provider-openstack repo against huaweicloud
+    run: playbooks/terraform-provider-openstack-acceptance-test-huaweicloud/run.yaml
+    secrets:
+      - huaweicloud_credentials
+
 # Gophercloud acceptance tests with Telefonica cloud
 - job:
     name: gophercloud-acceptance-test-telefonica
@@ -163,7 +203,6 @@
     run: playbooks/terraform-provider-telefonicaopencloud-acceptance-test-telefonica/run.yaml
     secrets:
       - telefonica_credentials
-
 
 # terraform-provider-flexibleengine acceptance tests with orange cloud
 - job:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -122,6 +122,19 @@
             branches: master
 
 - project:
+    name: terraform-providers/terraform-provider-openstack
+    periodic:
+      jobs:
+        - terraform-provider-openstack-acceptance-test-telefonica:
+            branches: master
+        - terraform-provider-openstack-acceptance-test-opentelekomcloud:
+            branches: master
+        - terraform-provider-openstack-acceptance-test-orange:
+            branches: master
+        - terraform-provider-openstack-acceptance-test-huaweicloud:
+            branches: master
+
+- project:
     name: cloudfoundry-incubator/bosh-huaweicloud-cpi-release
     check-generic-cloud:
       jobs:


### PR DESCRIPTION
Add jobs to integrate terraform-provider-openstack with
public clouds: telefonica, orange, opentelekomcloud and huaweicloud.

Related-Bug: theopenlab/openlab#125