### PR TITLE
Clean forked project theopenlab/packer and theopenlab/machine

### DIFF
--- a/roles/config-packer/tasks/main.yaml
+++ b/roles/config-packer/tasks/main.yaml
@@ -7,12 +7,12 @@
     - name: install packer from source
       shell: |
         set -ex
-        mkdir -p $GOPATH/src/github.com/hashicorp/packer
-        cp -r '{{ zuul.project.src_dir }}' $GOPATH/src/github.com/hashicorp/
-        cd $GOPATH/src/github.com/hashicorp/packer
         make dev
         packer version
       environment: '{{ global_env }}'
+      args:
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
   when:
     - packer_version == "master"
 

--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -176,12 +176,12 @@
 
 - pipeline:
     name: periodic
-    description: Jobs in this queue are triggered on a timer. UTC-0 0:00, 8:00 and 16:00
+    description: Jobs in this queue are triggered on a timer. UTC-0 04:00, 08:00 and 16:00
     manager: independent
     precedence: low
     trigger:
       timer:
-        - time: '0 0,8,16 * * *'
+        - time: '0 4,8,16 * * *'
     success:
       mysql:
     failure:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -58,7 +58,7 @@
             branches: stable-2.6
 
 - project:
-    name: theopenlab/packer
+    name: hashicorp/packer
     periodic:
       jobs:
         - packer-1.2.5-functional-opentelekomcloud:
@@ -69,6 +69,8 @@
 #        - packer-1.2.5-functional-telefonica:
 #            branches: master
         - packer-1.2.5-functional-huaweicloud:
+            branches: master
+        - packer-master-functional-devstack:
             branches: master
         - packer-1.2.5-functional-devstack:
             branches: master
@@ -84,12 +86,9 @@
             branches: master
         - packer-1.2.5-functional-devstack-mitaka:
             branches: master
-    check:
-      jobs:
-        - packer-master-functional-devstack
 
 - project:
-    name: theopenlab/machine
+    name: docker/machine
     periodic:
       jobs:
         - docker-machine-0.15.0-functional-opentelekomcloud:


### PR DESCRIPTION
1. Use upstream projects to instead of OpenLab forked projects to
   avoid syncing with upstream manually.
2. Add UTC-0 04:00 in periodic pipeline in order to have more chance
   to trigger periodic jobs and show issue of periodic jobs

Closes: theopenlab/openlab#133