### PR TITLE
Do refactor for docker-machine jobs

### DIFF
--- a/playbooks/docker-machine-functional-devstack/run.yaml
+++ b/playbooks/docker-machine-functional-devstack/run.yaml
@@ -7,40 +7,16 @@
     - clone-devstack-gate-to-workspace
     - create-devstack-local-conf
     - install-devstack
-    - config-golang
+    - config-docker-machine
   tasks:
     - name: Run Integration tests of Docker machine against devstack
       shell:
         cmd: |
           set -ex
-          git clone https://github.com/sstephenson/bats.git
-          pushd bats
-          ./install.sh /usr/local
-          popd
-          apt-get update
-          apt-get install apt-transport-https ca-certificates
-          wget -qO- https://get.docker.com/ | sh
 
           curl -O http://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
           openstack image create --file xenial-server-cloudimg-amd64-disk1.img --min-disk 1 --container-format bare \
               --disk-format qcow2 "Ubuntu 16.04 Server 64bit"
-          mkdir -p $GOPATH/src/github.com/docker/machine
-          cp -r '{{ ansible_user_dir }}/{{ zuul.project.src_dir }}' $GOPATH/src/github.com/docker
-          pushd $GOPATH/src/github.com/docker/machine
-          # NOTE: backport fix of PR 4543 and PR 4545
-          git config --global user.email 'zuul@openlab.com'
-          git config --global user.name 'openlab'
-          git cherry-pick 9ec6729
-          git cherry-pick 7909ee3
-          make build
-          cp ./bin/docker-machine /usr/local/bin/
-          docker-machine version
-          export OS_FLAVOR_ID=11
-          export OS_IMAGE_NAME="Ubuntu 16.04 Server 64bit"
-          export OS_SSH_USER=ubuntu
-          export OS_NETWORK_NAME=private
-          export OS_FLOATINGIP_POOL=public
-          export OS_DOMAIN_ID=default
 
           project_id=$(openstack token issue -f value -c project_id)
           sg_id=$(openstack security group list | grep default | grep $project_id | head -n 1 | awk '{print $2}')
@@ -54,6 +30,18 @@
           $sg_cmd_prefix icmp $sg_id
           neutron subnet-update --dns-nameserver 8.8.8.8 private-subnet
           openstack flavor create --vcpus 1 --ram 1024 --disk 10 --id 11 docker-machine-test
+
+          pushd '{{ ansible_user_dir }}/{{ zuul.project.src_dir }}'
+          export OS_FLAVOR_ID=11
+          export OS_IMAGE_NAME="Ubuntu 16.04 Server 64bit"
+          export OS_SSH_USER=ubuntu
+          export OS_TENANT_ID=$(openstack token issue -f value -c project_id)
+          export OS_NETWORK_NAME=private
+          export OS_FLOATINGIP_POOL=public
+          export OS_SECURITY_GROUPS=default
+
+          export OS_DOMAIN_ID=default
+
           export DRIVER=openstack
           export DEBUG=true
           export VERBOSE=true
@@ -65,6 +53,13 @@
           export B2D_LOCATION=~/.docker/machine/cache/boot2docker.iso
           export SHARED_NAME="bats-$DRIVER-test-shared-$(date +%s)"
           export MACHINE_BUGSNAG_API_TOKEN=no-report
+
+          # Install bats
+          git clone https://github.com/sstephenson/bats.git '{{ ansible_user_dir }}/bats'
+          pushd '{{ ansible_user_dir }}/bats'
+          ./install.sh /usr/local
+          popd
+
           function machine() {
               "$MACHINE_ROOT"/bin/"$MACHINE_BIN_NAME" "$@"
           }

--- a/playbooks/docker-machine-functional-public-clouds/run.yaml
+++ b/playbooks/docker-machine-functional-public-clouds/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
     - export-cloud-openrc
-    - config-golang
+    - config-docker-machine
   tasks:
     - name: Run integration tests of docker machine aganist {{ cloud_name }}
       block:
@@ -10,42 +10,22 @@
           shell:
             cmd: |
               set -ex
-              unset OS_DOMAIN_ID
+
               pip install python-openstackclient
-              git clone https://github.com/sstephenson/bats.git
-              pushd bats
-              ./install.sh /usr/local
-              popd
-              apt-get update
-              apt-get install apt-transport-https ca-certificates
-              wget -qO- https://get.docker.com/ | sh
 
-              mkdir -p $GOPATH/src/github.com/docker/machine
-              cp -r '{{ ansible_user_dir }}/{{ zuul.project.src_dir }}' $GOPATH/src/github.com/docker/
-              pushd $GOPATH/src/github.com/docker/machine
-              # NOTE: backport fix of PR 4543 and PR 4545
-              git config --global user.email 'zuul@openlab.com'
-              git config --global user.name 'openlab'
-              git cherry-pick 9ec6729
-              git cherry-pick 7909ee3
-
-              make build
-              cp ./bin/docker-machine /usr/local/bin/
-              docker-machine version
-              popd
-
+              pushd '{{ ansible_user_dir }}/{{ zuul.project.src_dir }}'
               # Select a flavor have 2048M memory and 2 vCPU at least
               export OS_FLAVOR_ID=$(openstack flavor list -f value -c ID -c RAM -c VCPUs --sort-column RAM --sort-column \
                   VCPUs | awk '{if($2>=2048 && $3>=2){print $1}}' | head -n 1)
               export OS_IMAGE_NAME="Ubuntu 16.04 Server 64bit"
+              export OS_SSH_USER="{{ ssh_user | default('ubuntu') }}"
               export OS_TENANT_ID=$(openstack token issue -f value -c project_id)
               export OS_NETWORK_NAME=openlab-jobs-net
               export OS_FLOATINGIP_POOL="admin_external_net"
               export OS_SECURITY_GROUPS="openlab-jobs-sg"
-              export OS_SSH_USER="{{ ssh_user | default('ubuntu') }}"
-              unset OS_AVAILABILITY_ZONE
 
-              pushd $GOPATH/src/github.com/docker/machine
+              unset OS_AVAILABILITY_ZONE
+              unset OS_DOMAIN_ID
 
               export DRIVER=openstack
               export DEBUG=true
@@ -58,6 +38,12 @@
               export B2D_LOCATION=~/.docker/machine/cache/boot2docker.iso
               export SHARED_NAME="bats-$DRIVER-test-shared-$(date +%s)"
               export MACHINE_BUGSNAG_API_TOKEN=no-report
+
+              # Install bats
+              git clone https://github.com/sstephenson/bats.git '{{ ansible_user_dir }}/bats'
+              pushd '{{ ansible_user_dir }}/bats'
+              ./install.sh /usr/local
+              popd
 
               function machine() {
                   "$MACHINE_ROOT"/bin/"$MACHINE_BIN_NAME" "$@"

--- a/roles/config-docker-machine/tasks/main.yaml
+++ b/roles/config-docker-machine/tasks/main.yaml
@@ -1,0 +1,28 @@
+---
+- name: Install and config golang
+  include_role:
+    name: config-golang
+
+- name: Compiled and install docker-machine from source
+  shell:
+    cmd: |
+      set -ex
+
+      # Install docker
+      apt-get update
+      apt-get install apt-transport-https ca-certificates
+      wget -qO- https://get.docker.com/ | sh
+
+      # NOTE: backport fix of PR 4543 and PR 4545
+      git config --global user.email 'zuul@openlab.com'
+      git config --global user.name 'openlab'
+      git cherry-pick 9ec6729
+      git cherry-pick 7909ee3
+
+      # Build docker-machine
+      make build
+      cp ./bin/docker-machine /usr/local/bin/
+      docker-machine version
+    executable: /bin/bash
+    chdir: '{{ zuul.project.src_dir }}'
+  environment: '{{ global_env }}'


### PR DESCRIPTION
1. Add role "config-docker-machine" to compiled and install
   docker-machine from source code.
2. Change job logic in order to putting related code together
3. Fix cp to same path issue, because we have used upstream project,
   don't need to cp forked project into official path

Related-Bug: theopenlab/openlab#133