### PR TITLE
Disable terraform periodic jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -120,18 +120,18 @@
         - cluster-api-provider-openstack-image-build:
             branches: master
 
-- project:
-    name: terraform-providers/terraform-provider-openstack
-    periodic:
-      jobs:
-        - terraform-provider-openstack-acceptance-test-telefonica:
-            branches: master
-        - terraform-provider-openstack-acceptance-test-opentelekomcloud:
-            branches: master
-        - terraform-provider-openstack-acceptance-test-orange:
-            branches: master
-        - terraform-provider-openstack-acceptance-test-huaweicloud:
-            branches: master
+#- project:
+#    name: terraform-providers/terraform-provider-openstack
+#    periodic:
+#      jobs:
+#        - terraform-provider-openstack-acceptance-test-telefonica:
+#            branches: master
+#        - terraform-provider-openstack-acceptance-test-opentelekomcloud:
+#            branches: master
+#        - terraform-provider-openstack-acceptance-test-orange:
+#            branches: master
+#        - terraform-provider-openstack-acceptance-test-huaweicloud:
+#            branches: master
 
 - project:
     name: cloudfoundry-incubator/bosh-huaweicloud-cpi-release


### PR DESCRIPTION
We forget to cleanup hanging resources when test cases failed
in terraform periodic jobs, disable these jobs temporarily to
avoid resource usage touch quota limit.

Related-Bug: theopenlab/openlab#136