### PR TITLE
Use different properties and existed id to test confliction cases

### DIFF
--- a/playbooks/osb-checker-test-huaweicloud/osb-checker-config-huaweicloud-dcs.json.j2
+++ b/playbooks/osb-checker-test-huaweicloud/osb-checker-config-huaweicloud-dcs.json.j2
@@ -58,7 +58,7 @@
         "plan_id": "d54d393b-f5ce-4eb7-86be-49da00606368",
         "async": true,
         "parameters": {
-            "name": "osb-checker-dcs-redis-{{ name_uuid }}",
+            "name": "osb-checker-dcs-redis-conflict-{{ name_uuid }}",
             "username": "username",
             "password": "Password1234!",
             "description": "Redis Single Node Test"

--- a/playbooks/osb-checker-test-huaweicloud/osb-checker-config-huaweicloud-dms.json.j2
+++ b/playbooks/osb-checker-test-huaweicloud/osb-checker-config-huaweicloud-dms.json.j2
@@ -56,7 +56,7 @@
         "plan_id": "d0c150cb-6a2a-47aa-8937-9c55d4615e14",
         "async": true,
         "parameters": {
-            "name": "osb-checker-dms-{{ name_uuid }}",
+            "name": "osb-checker-dms-conflict-{{ name_uuid }}",
             "username": "username",
             "password": "Password1234!",
             "description": "RabbitMQ Single Node Test"

--- a/playbooks/osb-checker-test-huaweicloud/osb-checker-config-huaweicloud-obs.json.j2
+++ b/playbooks/osb-checker-test-huaweicloud/osb-checker-config-huaweicloud-obs.json.j2
@@ -52,7 +52,7 @@
         "plan_id": "df0312bf-8189-4482-826e-2370a7f4d805",
         "async": true,
         "parameters": {
-            "bucket_name": "osb-checker-obs-{{ name_uuid }}",
+            "bucket_name": "osb-checker-obs-conflict-{{ name_uuid }}",
             "bucket_policy": "public-read-write"
         }
     }

--- a/playbooks/osb-checker-test-huaweicloud/osb-checker-config-huaweicloud-rds.json.j2
+++ b/playbooks/osb-checker-test-huaweicloud/osb-checker-config-huaweicloud-rds.json.j2
@@ -53,7 +53,7 @@
         "plan_id": "839f4458-309a-4e05-a069-807e950cf6da",
         "async": true,
         "parameters": {
-            "name": "osb-checker-rds-mysql-{{ name_uuid }}",
+            "name": "osb-checker-rds-mysql-conflict-{{ name_uuid }}",
             "database_password": "Password1234!"
         }
     }


### PR DESCRIPTION
According to the openservicebroker spec, the 409 conflict status of
provision should only be return when pass different properties and an
existed id.

Closes: theopenlab/openlab#138