### PR TITLE
Remove OS_SHARE_NETWORK_ID

### DIFF
--- a/playbooks/gophercloud-acceptance-test-telefonica/run.yaml
+++ b/playbooks/gophercloud-acceptance-test-telefonica/run.yaml
@@ -12,7 +12,6 @@
           apt-get install python-pip -y
           pip install -U python-openstackclient
 
-          export OS_SHARE_NETWORK_ID="foobar"
           export OS_FLAVOR_ID_RESIZE=2
           export OS_FLAVOR_ID=1
           export OS_POOL_NAME="admin_external_net"
@@ -31,6 +30,7 @@
               export OS_NETWORK_ID="$(openstack network create $OS_NETWORK_NAME -f value -c id)"
               openstack subnet create --network $OS_NETWORK_ID --subnet-range 10.0.10.0/24 $_NET_PREFIX-subnet
           fi
+          export OS_SUBNET_ID="$(openstack subnet show $_NET_PREFIX-subnet -f value -c id)"
 
           export OS_VPC_ID="$(openstack router show $_NET_PREFIX-vpc -f value -c id)"
           if [ -z "$OS_VPC_ID" ]; then

--- a/playbooks/terraform-provider-flexibleengine-acceptance-test-orange/run.yaml
+++ b/playbooks/terraform-provider-flexibleengine-acceptance-test-orange/run.yaml
@@ -12,7 +12,6 @@
           apt-get install python-pip -y
           pip install -U python-openstackclient
 
-          export OS_SHARE_NETWORK_ID="foobar"
           export OS_FLAVOR_ID_RESIZE="t2.small"
           export OS_FLAVOR_ID="t2.micro"
           export OS_POOL_NAME="admin_external_net"

--- a/playbooks/terraform-provider-huaweicloud-acceptance-test-fusioncloud/run.yaml
+++ b/playbooks/terraform-provider-huaweicloud-acceptance-test-fusioncloud/run.yaml
@@ -35,7 +35,6 @@
           shopt -s expand_aliases
           alias openstack="openstack --insecure"
 
-          export OS_SHARE_NETWORK_ID="foobar"
           export OS_FLAVOR_ID_RESIZE='rds.s1.medium'
           export OS_FLAVOR_ID='rds.c2.medium'
           export OS_POOL_NAME="DemoCenter_extenalNet"

--- a/playbooks/terraform-provider-openstack-acceptance-test-designate/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-designate/run.yaml
@@ -33,7 +33,6 @@
           echo export OS_POOL_NAME="public" >> openrc
           echo export OS_FLAVOR_ID=99 >> openrc
           echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
-          echo export OS_SHARE_NETWORK_ID=foobar >> openrc
           source openrc demo demo
           popd
           # Run the DNS test 100 testcases at a time

--- a/playbooks/terraform-provider-openstack-acceptance-test-fwaas/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-fwaas/run.yaml
@@ -32,7 +32,6 @@
           echo export OS_POOL_NAME="public" >> openrc
           echo export OS_FLAVOR_ID=99 >> openrc
           echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
-          echo export OS_SHARE_NETWORK_ID=foobar >> openrc
           source openrc demo demo
           popd
 

--- a/playbooks/terraform-provider-openstack-acceptance-test-lbaas/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-lbaas/run.yaml
@@ -32,7 +32,6 @@
           echo export OS_POOL_NAME="public" >> openrc
           echo export OS_FLAVOR_ID=99 >> openrc
           echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
-          echo export OS_SHARE_NETWORK_ID=foobar >> openrc
           echo export OS_USE_OCTAVIA=true >> openrc
           source openrc demo demo
           popd

--- a/playbooks/terraform-provider-openstack-acceptance-test-public-clouds/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-public-clouds/run.yaml
@@ -15,7 +15,6 @@
           set -x
 
           unset OS_DOMAIN_ID
-          export OS_SHARE_NETWORK_ID="foobar"
           export OS_FLAVOR_ID=$(openstack flavor list -f value -c ID -c RAM -c VCPUs --sort-column RAM --sort-column VCPUs | head -n 1 | awk '{print $1}')
           export OS_FLAVOR_ID_RESIZE=$(openstack flavor list -f value -c ID -c RAM -c VCPUs --sort-column RAM --sort-column VCPUs | awk '{if($2>=2048 && $3>=1){print $1}}' | head -n 1)
           export OS_POOL_NAME="admin_external_net"

--- a/playbooks/terraform-provider-openstack-acceptance-test-trove/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-trove/run.yaml
@@ -69,7 +69,6 @@
           # echo export OS_FLAVOR_ID=99 >> openrc
           echo export OS_FLAVOR_ID=15 >> openrc
           echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
-          echo export OS_SHARE_NETWORK_ID=foobar >> openrc
           source openrc demo demo
           popd
 

--- a/playbooks/terraform-provider-openstack-acceptance-test/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test/run.yaml
@@ -34,7 +34,6 @@
           echo export OS_POOL_NAME="public" >> openrc
           echo export OS_FLAVOR_ID=99 >> openrc
           echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
-          echo export OS_SHARE_NETWORK_ID=foobar >> openrc
           echo export OS_DOMAIN_ID=default >> openrc
           source openrc demo demo
           popd

--- a/playbooks/terraform-provider-opentelekomcloud-acceptance-test-opentelekomcloud/run.yaml
+++ b/playbooks/terraform-provider-opentelekomcloud-acceptance-test-opentelekomcloud/run.yaml
@@ -14,7 +14,6 @@
 
           set -o pipefail
           set -x
-          export OS_SHARE_NETWORK_ID="foobar"
           export OS_FLAVOR_ID_RESIZE='computev2-1'
           export OS_FLAVOR_ID='computev1-1'
           export OS_POOL_NAME="admin_external_net"

--- a/playbooks/terraform-provider-telefonicaopencloud-acceptance-test-telefonica/run.yaml
+++ b/playbooks/terraform-provider-telefonicaopencloud-acceptance-test-telefonica/run.yaml
@@ -12,7 +12,6 @@
           apt-get install python-pip -y
           pip install -U python-openstackclient
 
-          export OS_SHARE_NETWORK_ID="foobar"
           export OS_FLAVOR_ID_RESIZE='c2.medium'
           export OS_FLAVOR_ID='c1.medium'
           export OS_POOL_NAME="admin_external_net"

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -124,8 +124,9 @@
     name: terraform-providers/terraform-provider-openstack
     periodic:
       jobs:
-        - terraform-provider-openstack-acceptance-test-telefonica:
-            branches: master
+#        NOTES: Telefonica account is disable
+#        - terraform-provider-openstack-acceptance-test-telefonica:
+#            branches: master
         - terraform-provider-openstack-acceptance-test-opentelekomcloud:
             branches: master
         - terraform-provider-openstack-acceptance-test-orange:


### PR DESCRIPTION
- remove OS_SHARE_NETWORK_ID in terraform and gophercloud jobs
- disable terraform telefornica job

Closes: theopenlab/openlab#139