### PR TITLE
Skip VPC peering and vpc routes datasource tests

### DIFF
--- a/playbooks/terraform-provider-huaweicloud-acceptance-test-fusioncloud/run.yaml
+++ b/playbooks/terraform-provider-huaweicloud-acceptance-test-fusioncloud/run.yaml
@@ -60,8 +60,8 @@
           # Run test 100 testcases at a time
           exitcode=0
           alltestcases=`go test ./huaweicloud/ -v -list 'Acc'`
-          # skip the TestAccVpcPeeringConnectionV2DataSource_basic test, because it will raise a panic error and will break other tests running
-          testcases=`echo "$alltestcases" | sed '$d' | grep -v -e Kms -e Rds -e RDS -e SFS -e SMN -e DNS -e ELB -e Nat -e Images -e TestAccVpcPeering -e TestAccVpcRouteIdsV2DataSource_basic`
+          # skip the vpc peering and vpc peering routes data source tests, because it will raise a panic error and will break other tests running
+          testcases=`echo "$alltestcases" | sed '$d' | grep -v -e Kms -e Rds -e RDS -e SFS -e SMN -e DNS -e ELB -e Nat -e Images -e TestAccVpcPeeringConnectionV2DataSource_basic -e TestAccVpcRouteIdsV2DataSource_basic -e TestAccVpcRouteV2DataSource_basic`
           # Add OS_DEBUG=1 TF_LOG=debug flags for debuging
           echo "$testcases" | xargs -t -n100 sh -c 'OS_DEBUG=1 TF_LOG=debug TF_ACC=1 go test ./huaweicloud/ -v -timeout 240m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee -a $TEST_RESULTS_TXT || exitcode=$?
 


### PR DESCRIPTION
TestAccVpcPeeringConnectionV2DataSource_basic,
TestAccVpcRouteIdsV2DataSource_basic, TestAccVpcRouteV2DataSource_basic
will cause golang panic to interrupt test process, so skip theses.

Related-Bug: theopenlab/openlab#130