### PR TITLE
Diable S3 test cases in fusioncloud job

### DIFF
--- a/playbooks/terraform-provider-huaweicloud-acceptance-test-fusioncloud/post.yaml
+++ b/playbooks/terraform-provider-huaweicloud-acceptance-test-fusioncloud/post.yaml
@@ -17,7 +17,7 @@
           openstack port delete `openstack port list -f value -c ID -c Name |grep port_1 |awk '{ print $1 }'` || true
           openstack subnet delete `openstack subnet list -f value -c ID -c Name |grep -E 'tf_test_subnet|subnet_1|huaweicloud_subnet' |awk '{ print $1 }'` || true
           openstack network delete `openstack network list -f value -c ID -c Name |grep -E 'tf_test_network|network_1' |awk '{ print $1 }'` || true
-          openstack router delete `openstack router list -f value -c ID -c Name |grep -E 'test_vpc|vpc_test|vpc_test1|router_1|router_2|terraform-testacc-vpc-data-source' |awk '{ print $1 }'` || true
+          openstack router delete `openstack router list -f value -c ID -c Name |grep -E 'test_vpc|vpc_test|vpc_test1|router_1|router_2|terraform_provider_test|terraform_provider_test1|terraform-testacc-vpc-data-source' |awk '{ print $1 }'` || true
           openstack image delete `openstack image list -f value -c ID -c Name |grep -E 'CirrOS-tf|Rancher TerraformAccTest' |awk '{ print $1 }'` || true
           openstack keypair delete `openstack keypair list -f value -c Name |grep -E 'hth_key|kp_1'` || true
           openstack security group delete `openstack security group list -f value -c ID -c Name |grep -E 'sg_|secgroup_1' |awk '{ print $1 }'` || true

--- a/playbooks/terraform-provider-huaweicloud-acceptance-test-fusioncloud/run.yaml
+++ b/playbooks/terraform-provider-huaweicloud-acceptance-test-fusioncloud/run.yaml
@@ -43,12 +43,12 @@
           export OS_IMAGE_ID=$(openstack image show ${OS_IMAGE_NAME} -f value -c id)
           export OS_NETWORK_NAME="openlab-jobs-net"
           export OS_NETWORK_ID="$(openstack network show ${OS_NETWORK_NAME} -f value -c id)"
+          # Enable ULB(Neutron LB) tests, see terraform-providers/terraform-provider-huaweicloud#52
+          export OS_SUBNET_ID="$(openstack network show ${OS_NETWORK_NAME} -f value -c subnets)"
           export OS_VPC_ID="$(openstack router show openlab-jobs-vpc -f value -c id)"
           export OS_INSECURE=true
           # can only set one of OS_DOMAIN_ID and OS_DOMAIN_NAME
           unset OS_DOMAIN_ID
-          # Enable ULB(Neutron LB) tests
-          export OS_ULB_ENVIRONMENT=1
 
           # workaround
           sed -i s/Sys-default/default/ huaweicloud/resource_huaweicloud_compute_instance_v2.go
@@ -61,13 +61,13 @@
           exitcode=0
           alltestcases=`go test ./huaweicloud/ -v -list 'Acc'`
           # skip the vpc peering and vpc peering routes data source tests, because it will raise a panic error and will break other tests running
-          testcases=`echo "$alltestcases" | sed '$d' | grep -v -e Kms -e Rds -e RDS -e SFS -e SMN -e DNS -e ELB -e Nat -e Images -e TestAccVpcPeeringConnectionV2DataSource_basic -e TestAccVpcRouteIdsV2DataSource_basic -e TestAccVpcRouteV2DataSource_basic`
+          testcases=`echo "$alltestcases" | sed '$d' | grep -v -e Kms -e Rds -e RDS -e SFS -e SMN -e DNS -e ELB -e Nat -e S3 -e Images -e TestAccVpcPeeringConnectionV2DataSource_basic -e TestAccVpcRouteIdsV2DataSource_basic -e TestAccVpcRouteV2DataSource_basic`
           # Add OS_DEBUG=1 TF_LOG=debug flags for debuging
-          echo "$testcases" | xargs -t -n100 sh -c 'OS_DEBUG=1 TF_LOG=debug TF_ACC=1 go test ./huaweicloud/ -v -timeout 240m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee -a $TEST_RESULTS_TXT || exitcode=$?
+          echo "$testcases" | xargs -t -n100 sh -c 'OS_DEBUG=1 TF_LOG=debug TF_ACC=1 go test ./huaweicloud/ -v -timeout 300m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee -a $TEST_RESULTS_TXT || exitcode=$?
 
           # Run image tests in a separate process to avoid messy output
           imagetestcases=`echo "$alltestcases" | sed '$d' | grep Images`
-          echo "$imagetestcases" | xargs -t -n100 sh -c 'TF_LOG=debug TF_ACC=1 go test ./huaweicloud/ -v -timeout 240m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee -a $TEST_RESULTS_TXT || exitcode=$?
+          echo "$imagetestcases" | xargs -t -n100 sh -c 'TF_LOG=debug TF_ACC=1 go test ./huaweicloud/ -v -timeout 300m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee -a $TEST_RESULTS_TXT || exitcode=$?
 
           exit $exitcode
         executable: /bin/bash

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1030,13 +1030,12 @@
 
 # terraform-provider-huaweicloud acceptance tests against FusionCloud
 - job:
-    name: terraform-provider-huaweicloud-v1.2.0-acceptance-test-fusioncloud
+    name: terraform-provider-huaweicloud-acceptance-test-fusioncloud
     parent: golang-test
     description: |
       Run acceptance tests of terraform-provider-huaweicloud repo against fusioncloud
     run: playbooks/terraform-provider-huaweicloud-acceptance-test-fusioncloud/run.yaml
     post-run: playbooks/terraform-provider-huaweicloud-acceptance-test-fusioncloud/post.yaml
-    timeout: 14400
+    timeout: 18000
     secrets:
       - fusioncloud_credentials
-    override-checkout: v1.2.0

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -170,5 +170,5 @@
     name: terraform-providers/terraform-provider-huaweicloud
     periodic:
       jobs:
-        - terraform-provider-huaweicloud-v1.2.0-acceptance-test-fusioncloud:
+        - terraform-provider-huaweicloud-acceptance-test-fusioncloud:
             branches: master


### PR DESCRIPTION
- Disable all of S3 test cases
- Cleanup router "terraform_provider_test" and "terraform_provider_test1"
- Rename job "terraform-provider-huaweicloud-v1.2.0-acceptance-test-fusioncloud" to
  "terraform-provider-huaweicloud-acceptance-test-fusioncloud"
- Use master terraform-provider-huaweicloud to run tests
- Set timeout to 5 hours to avoid fusioncloud running job broken

Related-Bug: theopenlab/openlab#130