### PR TITLE
Skip the tests of unsupported services

### DIFF
--- a/playbooks/terraform-provider-huaweicloud-acceptance-test-fusioncloud/run.yaml
+++ b/playbooks/terraform-provider-huaweicloud-acceptance-test-fusioncloud/run.yaml
@@ -61,7 +61,8 @@
           exitcode=0
           alltestcases=`go test ./huaweicloud/ -v -list 'Acc'`
           # skip the vpc peering and vpc peering routes data source tests, because it will raise a panic error and will break other tests running
-          testcases=`echo "$alltestcases" | sed '$d' | grep -v -e Kms -e Rds -e RDS -e SFS -e SMN -e DNS -e ELB -e Nat -e S3 -e Images -e TestAccVpcPeeringConnectionV2DataSource_basic -e TestAccVpcRouteIdsV2DataSource_basic -e TestAccVpcRouteV2DataSource_basic`
+          # skip the cce, csbs, cts, dms and vbsbackup tests, these services are not supported in fusioncloud
+          testcases=`echo "$alltestcases" | sed '$d' | grep -v -e Kms -e Rds -e RDS -e SFS -e SMN -e DNS -e ELB -e Nat -e S3 -e Images -e CCE -e CSBS -e CTS -e Dms -e VBSBackup -e TestAccVpcPeeringConnectionV2DataSource_basic -e TestAccVpcRouteIdsV2DataSource_basic -e TestAccVpcRouteV2DataSource_basic`
           # Add OS_DEBUG=1 TF_LOG=debug flags for debuging
           echo "$testcases" | xargs -t -n100 sh -c 'OS_DEBUG=1 TF_LOG=debug TF_ACC=1 go test ./huaweicloud/ -v -timeout 300m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee -a $TEST_RESULTS_TXT || exitcode=$?
 


### PR DESCRIPTION
Skip the cce, csbs, cts, dms and vbsbackup tests,
these services are not supported in fusioncloud.

Related-Bug: theopenlab/openlab#130