### PR TITLE
Change periodic jobs trigger time

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -176,12 +176,12 @@
 
 - pipeline:
     name: periodic
-    description: Jobs in this queue are triggered on a timer. UTC-0 04:00, 08:00 and 16:00
+    description: Jobs in this queue are triggered on a timer. UTC-0 04:00, 09:00 and 16:00
     manager: independent
     precedence: low
     trigger:
       timer:
-        - time: '0 4,8,16 * * *'
+        - time: '0 4,9,16 * * *'
     success:
       mysql:
     failure:


### PR DESCRIPTION
- Change periodic jobs trigger time to UTC-0 04:00, 09:00 and 16:00
  to avoid fusioncloud long job miss trigger point

Related-Bug: theopenlab/openlab#130