### PR TITLE
Add domain name mapping for terraform fusioncloud job

### DIFF
--- a/playbooks/terraform-provider-huaweicloud-acceptance-test-fusioncloud/run.yaml
+++ b/playbooks/terraform-provider-huaweicloud-acceptance-test-fusioncloud/run.yaml
@@ -6,6 +6,23 @@
       vars:
         cloud_name: 'fusioncloud'
   tasks:
+    - name: workaround for fusioncloud domain name mapping
+      shell:
+        cmd: |
+          cat << EOF >> /etc/hosts
+          58.255.93.185 iam-apigateway-proxy.fusioncloud.huawei.com
+          58.255.93.185 iam-cache-proxy.fusioncloud.huawei.com
+          58.255.93.185 ecs-api.fusioncloud.huawei.com
+          58.255.93.185 evs-api.fusioncloud.huawei.com
+          58.255.93.185 vpc-api.fusioncloud.huawei.com
+          58.255.93.185 bms-api.fusioncloud.huawei.com
+          58.255.93.185 ccs-api.fusioncloud.huawei.com
+          58.255.93.185 as-api.fusioncloud.huawei.com
+          58.255.93.185 ims-api.fusioncloud.huawei.com
+          58.255.93.185 rts-api.fusioncloud.huawei.com
+          EOF
+        executable: /bin/bash
+
     - name: Run acceptance tests with terraform-provider-huaweicloud against fusioncloud
       shell:
         cmd: |


### PR DESCRIPTION
Because the endpoints of fusioncloud environment have been changed, and
new domain name cannot access directly, so we need to add domain name
mapping again.