### PR TITLE
Run npm install under osb-checker/common

### DIFF
--- a/playbooks/osb-checker-test-huaweicloud/run.yaml
+++ b/playbooks/osb-checker-test-huaweicloud/run.yaml
@@ -83,6 +83,9 @@
           sleep 20
 
           # openservicebrokerapi/osb-checker is required project. Run tests
+          pushd $GOPATH/src/github.com/openservicebrokerapi/osb-checker/common/
+          npm install
+          popd
           pushd $GOPATH/src/github.com/openservicebrokerapi/osb-checker/2.13/tests/
           npm install
           npm install --save-dev mocha-simple-html-reporter


### PR DESCRIPTION
As the osb-checker has been refactor, it need also to run `npm install`
under the osb-checker/common directory

Closes-Bug: #theopenlab/openlab#144