### PR TITLE
Modify the jobs-checker job because the newest ansible-lint

### DIFF
--- a/playbooks/openlab-zuul-jobs-check/run.yaml
+++ b/playbooks/openlab-zuul-jobs-check/run.yaml
@@ -8,7 +8,7 @@
           set -o pipefail
           set -x
           pip install ansible-lint
-          find playbooks -type f -regex '.*.y[a]?ml' -not -path "{{ excluded_path }}" -print0 | xargs -t -n1 -0 ansible-lint -xANSIBLE0012,ANSIBLE0013,ANSIBLE0006
+          find playbooks -type f -regex '.*.y[a]?ml' -not -path "{{ excluded_path }}" -print0 | xargs -t -n1 -0 ansible-lint -x204,301,206,305,303,405
           find playbooks -type f -regex '.*.y[a]?ml' -not -path "{{ excluded_path }}" -exec ansible-playbook -v --syntax-check -i ./playbooks/openlab-zuul-jobs-check/inventory \{\} + > /dev/null
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'


### PR DESCRIPTION
The newest ansible-lint 4.0.0 has change the command to specify the
skipped rules.

Closes-Bug: #theopenlab/openlab#145