### PR TITLE
Add OS_PROJECT_ID for fusioncloud secrets

### DIFF
--- a/roles/export-cloud-openrc/tasks/main.yaml
+++ b/roles/export-cloud-openrc/tasks/main.yaml
@@ -100,6 +100,7 @@
       OS_IDENTITY_API_VERSION: '{{ fusioncloud_credentials.identity_api_version }}'
       OS_DOMAIN_NAME: '{{ fusioncloud_credentials.domain_name }}'
       OS_PROJECT_NAME: '{{ fusioncloud_credentials.project_name}}'
+      OS_PROJECT_ID: '{{ fusioncloud_credentials.project_id}}'
       OS_REGION_NAME: '{{ fusioncloud_credentials.region_name}}'
       OS_TENANT_NAME: '{{ fusioncloud_credentials.project_name }}'
       OS_USERNAME: '{{ fusioncloud_credentials.user_name }}'

--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -736,6 +736,17 @@
           IbbcUPwUgnrIMMWC2icOKpy/q2YXvz9mfbtHtxuFBVMXDLk/ijBjTYsYi6LwmBMxJy15f
           O2PFAKmxvdCODzdB/s0sS6wnwSO0kbv/PpPrk4WJ4iZLDwBpDeV4hg8mBF+fAZkTzwJyx
           R/SyIqIyycqboDBIW0ZSrLaGJeevu/akJN2IwFB8oU0/Ygqwrl++xx9iufn4gw=
+      project_id: !encrypted/pkcs1-oaep
+        - bB0Lv37gCi/a4uwSG/x6t99lxdcRsT0hc9jEEOXK1b9tmIZ6rnWYrQVXpKAzszCgSH6HM
+          7nWXriibYPBVkz7/D3hQn507xcsFhc1vrAdEMyS3ng9ax5tVsWaFHZNDy0o+eEiGeANVw
+          Nq5MdZ504u9cNVbF0NkUlN8I8EBI/UHRUSOlFWU9DUkkvexwtZx8hfPp2H4iQbXMNGX/X
+          88QIHfjwKGbC+4eoRpSe6V5v4oT64wp/qHyY5jt98hbooev99S0RNaPFeuOZ3EUBWWSH2
+          MIT1q+pn0mK6yjHhlJux33TepVEq2yS/f55vo5k6GodI3osT/SP0FMpU6EQ7rbCMLKXOv
+          cgPgLeJlLS8+iMz+GxQMFSI8poDqDrFgEU1QtaTgBjK6ziN8Tcm+nVTNorCj1tHfl8w7i
+          nW1uuFTpPmVe9LxzGSlh1JulqRWca6t2otKcjCMdSyabYoXF0ktRusgD28dlYA/7ptbjG
+          u8WUun3FhP7kUsXGgBgopHjFlMQcMaC/ajYhhMyrXEtd+pkVsgu+QRgEoMSw2KfTAAO/S
+          mPXaIDRJlFFFmDSZKtUsMg+m1+o50GMH8eo6LzSXq7b4AfWphyz2eAxlFfHYQikl5ROhe
+          VfylzKMRbJHrurtlgYujEGWHZxm146WsiV6VHoa0qQqd8RfUrXxHFFVylma2jQ=
       region_name: !encrypted/pkcs1-oaep
         - av53WtB7hQHhlkhONd7gDNgqeFbc1hxhIX2o2wO5YZ+sqxpAOXAZkop0XTwJhHSehsk+Q
           yKUQ2/lOjOVotq9RO+5k/SXz0kOpxJHMTCniQhQUk0kfsU3+58HkvA+snsLNqneTOu0iW


### PR DESCRIPTION
AKSK auth need OS_PROJECT_ID to add into HTTP HEAD, os
we should add it into secrets.yaml and role.

Related-Bug: theopenlab/openlab#130