### PR TITLE
Set up Devstack with manila enbaling the LVM driver

### DIFF
--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -104,22 +104,31 @@
       set -e
       set -x
       cat << EOF >> /tmp/dg-local.conf
+      MANILA_MULTI_BACKEND=True
       MANILA_BACKEND1_CONFIG_GROUP_NAME=london
       MANILA_BACKEND2_CONFIG_GROUP_NAME=paris
       MANILA_SHARE_BACKEND1_NAME=LONDON
       MANILA_SHARE_BACKEND2_NAME=PARIS
-      MANILA_OPTGROUP_london_driver_handles_share_servers=True
-      MANILA_OPTGROUP_paris_driver_handles_share_servers=True
-      MANILA_USE_SERVICE_INSTANCE_PASSWORD=True
-      MANILA_USE_DOWNGRADE_MIGRATIONS=True
-      MANILA_MULTI_BACKEND=True
-      MANILA_ADMIN_NET_RANGE=10.2.5.0/24
-      MANILA_DATA_NODE_IP=10.2.5.0/24
-      MANILA_DATA_COPY_CHECK_HASH=True
-      MANILA_SHARE_MIGRATION_PERIOD_TASK_INTERVAL=1
-      SHARE_DRIVER=manila.share.drivers.generic.GenericShareDriver
-      MANILA_SERVICE_IMAGE_ENABLED=True
-      MANILA_DEFAULT_SHARE_TYPE_EXTRA_SPECS='snapshot_support=True create_share_from_snapshot_support=True'
+
+      # This local.conf sets up Devstack with manila enabling the LVM
+      # driver which operates in driver_handles_share_services=False mode
+      MANILA_OPTGROUP_london_driver_handles_share_servers=False
+      MANILA_OPTGROUP_paris_driver_handles_share_servers=False
+      SHARE_DRIVER=manila.share.drivers.lvm.LVMShareDriver
+      MANILA_DEFAULT_SHARE_TYPE_EXTRA_SPECS='snapshot_support=True create_share_from_snapshot_support=True revert_to_snapshot_support=True mount_snapshot_support=True'
+
+      # This local.conf sets up Devstack with manila enabling the Generic
+      # driver that uses Cinder to provide back-end storage and Nova to
+      # serve storage virtual machines (share servers) in the tenant's domain.
+      # This driver operates in driver_handles_share_services=True mode
+      #MANILA_OPTGROUP_london_driver_handles_share_servers=True
+      #MANILA_OPTGROUP_paris_driver_handles_share_servers=True
+      #MANILA_USE_SERVICE_INSTANCE_PASSWORD=True
+      #MANILA_ADMIN_NET_RANGE=10.2.5.0/24
+      #MANILA_DATA_NODE_IP=10.2.5.0/24
+      #SHARE_DRIVER=manila.share.drivers.generic.GenericShareDriver
+      #MANILA_SERVICE_IMAGE_ENABLED=True
+      #MANILA_DEFAULT_SHARE_TYPE_EXTRA_SPECS='snapshot_support=True create_share_from_snapshot_support=True'
 
       enable_plugin heat git://git.openstack.org/openstack/heat
       enable_plugin manila git://git.openstack.org/openstack/manila


### PR DESCRIPTION
Modify the local.conf to set up Devstack with manila
enabling the LVM driver which operates in
driver_handles_share_services=False mode.

Related-Bug: theopenlab/openlab#142