### PR TITLE
Add jobs of openshift origin + public clouds

### DIFF
--- a/playbooks/openshift-origin-functional-test-public-clouds/cluster-testing.yaml
+++ b/playbooks/openshift-origin-functional-test-public-clouds/cluster-testing.yaml
@@ -1,0 +1,84 @@
+---
+- name: Deploy example applications for testing cluster functionalities
+  hosts: masters
+  become: yes
+  tasks:
+  - name: Create resources in openshift cluster
+    shell:
+      cmd: |
+        set -xe
+        git clone http://github.com/huaweicloud/openshift-ansible
+        oc adm policy add-scc-to-group anyuid system:authenticated
+        oc create -f openshift-ansible/applications/
+        oc_get_running_pods() { oc get pods -o jsonpath='{range .items[*].status}{.phase}{"\n"}{end}'; }
+        export -f oc_get_running_pods
+        timeout 60 bash -c '
+            while :
+            do
+                [[ $(oc_get_running_pods | uniq) == Running ]] && break
+                sleep 2
+            done
+            '
+      executable: /bin/bash
+
+  - name: Record pvc cinder volumes name
+    shell: oc get pvc -o jsonpath='{range .items[*].spec}{.volumeName}{end}'
+    register: vol_name
+
+  - name: Record loadbalancer name
+    shell: oc get svc nginx-service -o jsonpath='{.metadata.uid}' | tr -d '-' | sed 's/^/a/' | cut -c -32
+    register: lbaas_id
+
+- name: Confirm the cloud resources has been created
+  hosts: localhost
+  become: yes
+  vars:
+    lbaas_name: '{{ hostvars[groups["masters"][0]]["lbaas_id"].stdout }}'
+    pvc_vol_name: '{{ hostvars[groups["masters"][0]]["vol_name"].stdout }}'
+  tasks:
+  - name: confirm resources in cloud
+    shell:
+      cmd: |
+        set -xe
+        timeout 60 bash -c '
+            while :
+            do
+                openstack volume show kubernetes-dynamic-{{ pvc_vol_name }} && \
+                neutron lbaas-loadbalancer-show {{ lbaas_name }} && break
+                sleep 2
+            done
+            '
+      executable: /bin/bash
+
+- name: Clean resources in openshift cluster
+  hosts: masters
+  become: yes
+  tasks:
+  - name: clean resources in openshift cluster
+    shell:
+      cmd: |
+        set -xe
+        oc delete -f openshift-ansible/applications/
+        oc delete all --all
+      executable: /bin/bash
+
+- name: Confirm the cloud resources has been removed
+  hosts: localhost
+  become: yes
+  vars:
+    lbaas_name: '{{ hostvars[groups["masters"][0]]["lbaas_id"].stdout }}'
+    pvc_vol_name: '{{ hostvars[groups["masters"][0]]["vol_name"].stdout }}'
+  tasks:
+  - name: confirm resources in cloud removed
+    shell:
+      cmd: |
+        set -xe
+        timeout 60 bash -c '
+            while :
+            do
+                ! openstack volume show kubernetes-dynamic-{{ pvc_vol_name }} && \
+                ! neutron lbaas-loadbalancer-show {{ lbaas_name }} && break
+                sleep 2
+            done
+            '
+      executable: /bin/bash

--- a/playbooks/openshift-origin-functional-test-public-clouds/extra_vars.yml.j2
+++ b/playbooks/openshift-origin-functional-test-public-clouds/extra_vars.yml.j2
@@ -1,0 +1,11 @@
+---
+{% if openshift_image_name is defined %}
+openshift_openstack_default_image_name: "{{ openshift_image_name }}"
+{% endif %}
+openshift_openstack_clusterid: "openshift-{{ job_uid }}"
+openshift_openstack_public_dns_domain: "openlab.com"
+openshift_openstack_keypair_name: "openshift-{{ job_uid }}"
+openshift_openstack_num_infra: 0
+openshift_openstack_num_nodes: 1
+openshift_release: "{{ openshift_release | default('3.9') }}"
+openshift_hosted_infra_selector: "node-role.kubernetes.io/master=true"

--- a/playbooks/openshift-origin-functional-test-public-clouds/post.yaml
+++ b/playbooks/openshift-origin-functional-test-public-clouds/post.yaml
@@ -1,0 +1,17 @@
+- hosts: all
+  become: yes
+  vars:
+    job_uid: '{{ zuul.build[:10] }}'
+  roles:
+    - export-cloud-openrc
+  tasks:
+    - name: Clean up resources of openshift cluster on {{ cloud_name }}
+      shell:
+        cmd: |
+          set -e
+          set -x
+          openstack stack delete --wait --yes "openshift-{{ job_uid }}.openlab.com" || true
+          openstack keypair delete "openshift-{{ job_uid }}" || true
+          openstack volume delete `openstack volume list --status available -f value -c Name |grep kubernetes-dynamic-pvc` || true
+        executable: /bin/bash
+      environment: '{{ global_env }}'

--- a/playbooks/openshift-origin-functional-test-public-clouds/run.yaml
+++ b/playbooks/openshift-origin-functional-test-public-clouds/run.yaml
@@ -1,0 +1,72 @@
+- hosts: all
+  become: yes
+  vars:
+    job_uid: '{{ zuul.build[:10] }}'
+  roles:
+    - export-cloud-openrc
+  tasks:
+    - name: Copy cluster testing playbook under openshift-ansible
+      become: yes
+      copy:
+        src: cluster-testing.yaml
+        dest: '{{ ansible_user_dir }}/src/github.com/huaweicloud/openshift-ansible/cluster-testing.yaml'
+
+    - name: Generate cloud specific extra vars for openshift cluster deployment
+      become: yes
+      template:
+        dest: "{{ ansible_user_dir }}/src/github.com/huaweicloud/openshift-ansible/extra_vars.yml"
+        src: "extra_vars.yml.j2"
+
+    - name: Run Openshift Origin functional tests against {{ cloud_name }}
+      shell:
+        cmd: |
+          set -xe
+          pip install ansible
+          pip install jinja2
+          pip install shade
+          pip install jmespath
+          pip install dnspython
+          pip install python-openstackclient
+          pip install python-heatclient
+          pip install python-neutronclient
+
+          openstack keypair create "openshift-{{ job_uid }}" > "openshift-{{ job_uid }}.pem"
+          chmod 400 "openshift-{{ job_uid }}.pem"
+
+          export ANSIBLE_HOST_KEY_CHECKING=false
+          export OPENSHIFT_CLUSTER="openshift-{{ job_uid }}.openlab.com"
+
+          # Check prerequisites
+          ansible-playbook --user root \
+              -i playbooks/openstack/inventory.py \
+              -i "playbooks/openstack/{{ inventory_name }}-inventory" \
+              --private-key "./openshift-{{ job_uid }}.pem" \
+              playbooks/openstack/openshift-cluster/prerequisites.yml \
+              -e @extra_vars.yml
+
+          # Provision
+          ansible-playbook --user root \
+              -i playbooks/openstack/inventory.py \
+              -i "playbooks/openstack/{{ inventory_name }}-inventory" \
+              --private-key "./openshift-{{ job_uid }}.pem" \
+              playbooks/openstack/openshift-cluster/provision.yml \
+              -e @extra_vars.yml
+
+          # Install openshift cluster
+          ansible-playbook --user root \
+              -i playbooks/openstack/inventory.py \
+              -i "playbooks/openstack/{{ inventory_name }}-inventory" \
+              --private-key "./openshift-{{ job_uid }}.pem"  \
+              playbooks/openstack/openshift-cluster/install.yml \
+              -e @extra_vars.yml
+
+          # Testing openshift cluster functionalities
+          ansible-playbook --user root \
+              -i playbooks/openstack/inventory.py \
+              -i "playbooks/openstack/{{ inventory_name }}-inventory" \
+              --private-key "./openshift-{{ job_uid }}.pem"  \
+              cluster-testing.yaml \
+              -e @extra_vars.yml
+        executable: /bin/bash
+        chdir: '{{ ansible_user_dir }}/src/github.com/huaweicloud/openshift-ansible'
+      environment: '{{ global_env }}'

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1039,3 +1039,56 @@
     timeout: 18000
     secrets:
       - fusioncloud_credentials
+
+- job:
+    name: openshift-origin-functional-test-huaweicloud
+    parent: init-test
+    description: |
+      Run functional tests of openshift-origin repo of v3.9.0 release against huaweicloud
+    run: playbooks/openshift-origin-functional-test-public-clouds/run.yaml
+    post-run: playbooks/openshift-origin-functional-test-public-clouds/post.yaml
+    vars:
+      cloud_name: huaweicloud
+      inventory_name: huawei
+      openshift_image_name: "CentOS 7.5 64bit"
+    secrets:
+      - huaweicloud_credentials
+
+- job:
+    name: openshift-origin-functional-test-opentelekomcloud
+    parent: init-test
+    description: |
+      Run functional tests of openshift-origin repo of v3.9.0 release against opentelekomcloud
+    run: playbooks/openshift-origin-functional-test-public-clouds/run.yaml
+    post-run: playbooks/openshift-origin-functional-test-public-clouds/post.yaml
+    vars:
+      cloud_name: opentelekomcloud
+      inventory_name: otc
+    secrets:
+      - opentelekomcloud_credentials
+
+- job:
+    name: openshift-origin-functional-test-telefonica
+    parent: init-test
+    description: |
+      Run functional tests of openshift-origin repo of v3.9.0 release against telefonica cloud
+    run: playbooks/openshift-origin-functional-test-public-clouds/run.yaml
+    post-run: playbooks/openshift-origin-functional-test-public-clouds/post.yaml
+    vars:
+      cloud_name: telefonica
+      inventory_name: telefonica
+    secrets:
+      - telefonica_credentials
+
+- job:
+    name: openshift-origin-functional-test-orange
+    parent: init-test
+    description: |
+      Run functional tests of openshift-origin repo of v3.9.0 release against orange cloud
+    run: playbooks/openshift-origin-functional-test-public-clouds/run.yaml
+    post-run: playbooks/openshift-origin-functional-test-public-clouds/post.yaml
+    vars:
+      cloud_name: orange
+      inventory_name: orange
+    secrets:
+      - orange_credentials

--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -188,6 +188,19 @@
       mysql:
 
 - pipeline:
+    name: periodic-utc-2
+    description: Jobs in this queue are triggered on a timer. UTC-0 02:00
+    manager: independent
+    precedence: low
+    trigger:
+      timer:
+        - time: '0 2 * * *'
+    success:
+      mysql:
+    failure:
+      mysql:
+
+- pipeline:
     name: merge-check
     description: >
       Each time a change merges, this pipeline verifies that all open changes

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -172,3 +172,14 @@
       jobs:
         - terraform-provider-huaweicloud-acceptance-test-fusioncloud:
             branches: master
+
+
+- project:
+    name: huaweicloud/openshift-ansible
+    periodic-utc-2:
+      jobs:
+        - openshift-origin-functional-test-huaweicloud
+        - openshift-origin-functional-test-opentelekomcloud
+        # NOTES: Telefonica account is disable
+        # - openshift-origin-functional-test-telefonica
+        - openshift-origin-functional-test-orange


### PR DESCRIPTION
This change add jobs:
  -  openshift-origin-v3.9.0-functional-test-huaweicloud
  - openshift-origin-v3.9.0-functional-test-opentelekomcloud
  - openshift-origin-v3.9.0-functional-test-telefonica
  - openshift-origin-v3.9.0-functional-test-orange

Implement: #theopenlab/openlab#149