### PR TITLE
Change the timeout of openshift job from 60s to 180s

### DIFF
--- a/playbooks/openshift-origin-functional-test-public-clouds/cluster-testing.yaml
+++ b/playbooks/openshift-origin-functional-test-public-clouds/cluster-testing.yaml
@@ -12,7 +12,7 @@
         oc create -f openshift-ansible/applications/
         oc_get_running_pods() { oc get pods -o jsonpath='{range .items[*].status}{.phase}{"\n"}{end}'; }
         export -f oc_get_running_pods
-        timeout 60 bash -c '
+        timeout 180 bash -c '
             while :
             do
                 [[ $(oc_get_running_pods | uniq) == Running ]] && break
@@ -40,7 +40,7 @@
     shell:
       cmd: |
         set -xe
-        timeout 60 bash -c '
+        timeout 180 bash -c '
             while :
             do
                 openstack volume show kubernetes-dynamic-{{ pvc_vol_name }} && \
@@ -73,7 +73,7 @@
     shell:
       cmd: |
         set -xe
-        timeout 60 bash -c '
+        timeout 180 bash -c '
             while :
             do
                 ! openstack volume show kubernetes-dynamic-{{ pvc_vol_name }} && \


### PR DESCRIPTION
Sometimes the resource cleanup may need to take a longer time.

Related: #theopenlab/openlab#149