### PR TITLE
Run all of manageiq jobs in periodic-2 pipeline

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -148,8 +148,8 @@
         - osb-checker-test-huaweicloud
 
 - project:
-    name: theopenlab/manageiq-providers-openstack
-    periodic:
+    name: manageiq/manageiq-providers-openstack
+    periodic-2:
       jobs:
         - manageiq-providers-openstack-test-devstack-master
         - manageiq-providers-openstack-test-devstack-mitaka
@@ -158,8 +158,6 @@
         - manageiq-providers-openstack-test-devstack-pike
         - manageiq-providers-openstack-test-devstack-queens
         - manageiq-providers-openstack-test-devstack-rocky
-    check-generic-cloud:
-      jobs:
         - manageiq-providers-openstack-test-huaweicloud
         - manageiq-providers-openstack-test-opentelekomcloud
         - manageiq-providers-openstack-test-orange


### PR DESCRIPTION
We trigger manageiq jobs in check-generic-cloud pipeline manually,
actually those jobs don't create any resource for public cloud environment,
so we can put them into periodic pipeline to be triggered automatically,
now we have periodic-2 pipeline run at UTC-0 22:00, that is a good time to
avoid tenant quota limit of public cloud account to run jobs, so plan to move
all of manageiq jobs into it, and we can switch to official project
manageiq/manageiq-providers-openstack in OpenLab configuration.

Close: theopenlab/openlab#152