### PR TITLE
Fix OpenSSL package downloading error

### DIFF
--- a/playbooks/manageiq-providers-openstack-test-devstack/run.yaml
+++ b/playbooks/manageiq-providers-openstack-test-devstack/run.yaml
@@ -76,10 +76,10 @@
           su postgres -c "psql -c \"CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'\""
 
           # Ubuntu fix for failing Bundler
-          wget -t 10 -T 2 http://ftp.debian.org/debian/pool/main/o/openssl1.0/libssl1.0-dev_1.0.2o-1_amd64.deb
-          wget -t 10 -T 2 http://ftp.debian.org/debian/pool/main/o/openssl1.0/libssl1.0.2_1.0.2o-1_amd64.deb
+          wget -t 10 -T 2 ftp://ftp.us.debian.org/debian/pool/main/o/openssl1.0/libssl1.0-dev_1.0.2?-?_amd64.deb
+          wget -t 10 -T 2 ftp://ftp.us.debian.org/debian/pool/main/o/openssl1.0/libssl1.0.2_1.0.2?-?_amd64.deb
           apt remove -y libssl-dev
-          dpkg -i libssl1.0-dev_1.0.2o-1_amd64.deb libssl1.0.2_1.0.2o-1_amd64.deb
+          dpkg -i libssl1.0-dev_1.0.2*-*_amd64.deb libssl1.0.2_1.0.2*-*_amd64.deb
           apt-get install -y python-psycopg2 libpq-dev
 
           # Prepare openstack_environments.yml

--- a/playbooks/manageiq-providers-openstack-test-public-clouds/run.yaml
+++ b/playbooks/manageiq-providers-openstack-test-public-clouds/run.yaml
@@ -35,10 +35,10 @@
           su postgres -c "psql -c \"CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'\""
 
           # Ubuntu fix for failing Bundler
-          wget http://ftp.debian.org/debian/pool/main/o/openssl1.0/libssl1.0-dev_1.0.2o-1_amd64.deb
-          wget http://ftp.debian.org/debian/pool/main/o/openssl1.0/libssl1.0.2_1.0.2o-1_amd64.deb
+          wget -t 10 -T 2 ftp://ftp.us.debian.org/debian/pool/main/o/openssl1.0/libssl1.0-dev_1.0.2?-?_amd64.deb
+          wget -t 10 -T 2 ftp://ftp.us.debian.org/debian/pool/main/o/openssl1.0/libssl1.0.2_1.0.2?-?_amd64.deb
           apt remove -y libssl-dev
-          dpkg -i libssl1.0-dev_1.0.2o-1_amd64.deb libssl1.0.2_1.0.2o-1_amd64.deb
+          dpkg -i libssl1.0-dev_1.0.2*-*_amd64.deb libssl1.0.2_1.0.2*-*_amd64.deb
 
           apt-get install -y postgresql python-psycopg2 libpq-dev
 


### PR DESCRIPTION
OpenSSL package update that casue ManageIQ jobs failed.
OpenSSL package name is changed, that cause wget failed and
ManageIQ jobs failed. We should use more flexbile way to get package.

Closes: theopenlab/openlab#158