### PR TITLE
Enable TF_SCHEMA_PANIC_ON_ERROR for terraform jobs

### DIFF
--- a/playbooks/terraform-provider-openstack-acceptance-test-designate/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-designate/run.yaml
@@ -39,7 +39,7 @@
           export OS_DNS_ENVIRONMENT=1 # for Designate tests
           testcases=`go test ./openstack/ -v -list 'Acc'`
           testcases=`echo "$testcases" | sed '$d' | grep DNS`
-          echo "$testcases" | xargs -t -n100 sh -c 'TF_LOG=DEBUG TF_ACC=1 go test ./openstack -v -timeout 120m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
+          echo "$testcases" | xargs -t -n100 sh -c 'TF_LOG=DEBUG TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./openstack -v -timeout 120m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'
       environment: '{{ global_env }}'

--- a/playbooks/terraform-provider-openstack-acceptance-test-fwaas/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-fwaas/run.yaml
@@ -39,7 +39,7 @@
           export OS_FW_ENVIRONMENT=1 # for FWaaS tests
           testcases=`go test ./openstack/ -v -list 'Acc'`
           testcases=`echo "$testcases" | sed '$d' | grep FW`
-          echo "$testcases" | xargs -t -n100 sh -c 'TF_LOG=DEBUG TF_ACC=1 go test ./openstack -v -timeout 120m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
+          echo "$testcases" | xargs -t -n100 sh -c 'TF_LOG=DEBUG TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./openstack -v -timeout 120m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'
       environment: '{{ global_env }}'

--- a/playbooks/terraform-provider-openstack-acceptance-test-lbaas/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-lbaas/run.yaml
@@ -40,7 +40,7 @@
           export OS_LB_ENVIRONMENT=1 # for LBaaS tests
           testcases=`go test ./openstack/ -v -list 'Acc'`
           testcases=`echo "$testcases" | sed '$d' | grep LB`
-          echo "$testcases" | xargs -t -n100 sh -c 'TF_LOG=DEBUG TF_ACC=1 go test ./openstack -v -timeout 120m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
+          echo "$testcases" | xargs -t -n100 sh -c 'TF_LOG=DEBUG TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./openstack -v -timeout 120m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'
       environment: '{{ global_env }}'

--- a/playbooks/terraform-provider-openstack-acceptance-test-public-clouds/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-public-clouds/run.yaml
@@ -32,7 +32,7 @@
           # Run except the DNS/FW/LB test 100 testcases at a time
           testcases=`go test ./openstack/ -v -list 'Acc'`
           testcases=`echo "$testcases" | sed '$d' | grep -v -e FW -e LB`
-          echo "$testcases" | xargs -t -n100 sh -c 'TF_LOG=DEBUG OS_DEBUG=1 TF_ACC=1 go test ./openstack -v -timeout 120m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
+          echo "$testcases" | xargs -t -n100 sh -c 'TF_LOG=DEBUG OS_DEBUG=1 TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./openstack -v -timeout 120m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
 
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'

--- a/playbooks/terraform-provider-openstack-acceptance-test-trove/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-trove/run.yaml
@@ -83,7 +83,7 @@
           export OS_DB_DATASTORE_VERSION=${mysql_version}
           testcases=`go test ./openstack/ -v -list 'Acc'`
           testcases=`echo "$testcases" | sed '$d' | grep Database`
-          echo "$testcases" | xargs -t -n100 sh -c 'TF_LOG=DEBUG TF_ACC=1 go test ./openstack -v -timeout 120m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
+          echo "$testcases" | xargs -t -n100 sh -c 'TF_LOG=DEBUG TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./openstack -v -timeout 120m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'
       environment: '{{ global_env }}'

--- a/playbooks/terraform-provider-openstack-acceptance-test/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test/run.yaml
@@ -42,7 +42,7 @@
           export OS_SWIFT_ENVIRONMENT=1 # for Swift tests
           testcases=`go test ./openstack/ -v -list 'Acc'`
           testcases=`echo "$testcases" | sed '$d' | grep -v -e FW -e LB`
-          echo "$testcases" | xargs -t -n100 sh -c 'OS_DEBUG=1 TF_LOG=DEBUG TF_ACC=1 go test ./openstack -v -timeout 120m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
+          echo "$testcases" | xargs -t -n100 sh -c 'OS_DEBUG=1 TF_LOG=DEBUG TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./openstack -v -timeout 120m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'
       environment: '{{ global_env }}'


### PR DESCRIPTION
The TF_SCHEMA_PANIC_ON_ERROR flag allows to catch invalid
terraform schema assignments. It would be great if we can
enable this environment flag.

Close: theopenlab/openlab#166