### PR TITLE
"make bin" to avoid "make dev" error in released packer version

### DIFF
--- a/roles/config-packer/tasks/main.yaml
+++ b/roles/config-packer/tasks/main.yaml
@@ -6,7 +6,7 @@
 - name: Install master of Packer from source
   shell: |
     set -ex
-    make dev
+    make bin
     packer version
   environment: '{{ global_env }}'
   args:


### PR DESCRIPTION
"make dev" of packer only can be used in an unreleased dev version
when we compile source code, so we should use "make bin" to avoid
periodic jobs of packer error because we pin released vesion by using
"override-checkout"

Closes: theopenlab/openlab#169