### PR TITLE
Clean up secgroup_2 for fusioncloud job

### DIFF
--- a/playbooks/terraform-provider-huaweicloud-acceptance-test-fusioncloud/post.yaml
+++ b/playbooks/terraform-provider-huaweicloud-acceptance-test-fusioncloud/post.yaml
@@ -15,13 +15,13 @@
           openstack server delete `openstack server list -f value -c ID -c Name |grep instance_1 |awk '{ print $1 }'` || true
           openstack volume delete `openstack volume list -f value -c ID -c Name |grep -E 'volume_1|vol_1' |awk '{ print $1 }'` || true
           neutron lbaas-loadbalancer-delete `neutron lbaas-loadbalancer-list -f value -c ID -c Name |grep loadbalancer_1 |awk '{ print $1 }'` || true
-          openstack port delete `openstack port list -f value -c ID -c Name |grep port_1 |awk '{ print $1 }'` || true
+          openstack port delete `openstack port list -f value -c ID -c Name |grep -E 'port_1|port_2' |awk '{ print $1 }'` || true
           openstack subnet delete `openstack subnet list -f value -c ID -c Name |grep -E 'tf_test_subnet|subnet_1|huaweicloud_subnet' |awk '{ print $1 }'` || true
           openstack network delete `openstack network list -f value -c ID -c Name |grep -E 'tf_test_network|network_1' |awk '{ print $1 }'` || true
           openstack router delete `openstack router list -f value -c ID -c Name |grep -E 'test_vpc|vpc_test|vpc_test1|router_1|router_2|terraform_provider_test|terraform_provider_test1|terraform-testacc-vpc-data-source' |awk '{ print $1 }'` || true
           openstack image delete `openstack image list -f value -c ID -c Name |grep -E 'CirrOS-tf|Rancher TerraformAccTest' |awk '{ print $1 }'` || true
           openstack keypair delete `openstack keypair list -f value -c Name |grep -E 'hth_key|kp_1'` || true
-          openstack security group delete `openstack security group list -f value -c ID -c Name |grep -E 'sg_|secgroup_1' |awk '{ print $1 }'` || true
+          openstack security group delete `openstack security group list -f value -c ID -c Name |grep -E 'sg_|secgroup_1|secgroup_2' |awk '{ print $1 }'` || true
           openstack floating ip delete `openstack floating ip list -f value -c ID -c Port |grep 'None' |awk '{ print $1 }'` || true
         executable: /bin/bash
       environment: '{{ global_env }}'


### PR DESCRIPTION
Sometimes secgroup_2 is residue after fusioncloud job
running, clean up it. And also we have to clean up port_2.

Closes: theopenlab/openlab#170