### PR TITLE
Adjust csi-attacher name for new release

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
@@ -116,7 +116,7 @@
 
           git clone https://github.com/kubernetes-csi/external-attacher ${GOPATH}/src/github.com/kubernetes-csi/external-attacher
           make -C ${GOPATH}/src/github.com/kubernetes-csi/external-attacher container
-          docker tag quay.io/k8scsi/csi-attacher:canary docker.io/k8scsi/csi-attacher:latest
+          docker tag csi-attacher:latest docker.io/k8scsi/csi-attacher:latest
 
           git clone https://github.com/kubernetes-csi/driver-registrar ${GOPATH}/src/github.com/kubernetes-csi/driver-registrar
           make -C ${GOPATH}/src/github.com/kubernetes-csi/driver-registrar container

--- a/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
@@ -110,18 +110,6 @@
           EOF
           docker build -t docker.io/k8scloudprovider/cinder-csi-plugin:latest .
 
-          git clone https://github.com/kubernetes-csi/external-provisioner ${GOPATH}/src/github.com/kubernetes-csi/external-provisioner
-          make -C ${GOPATH}/src/github.com/kubernetes-csi/external-provisioner container
-          docker tag quay.io/k8scsi/csi-provisioner:canary docker.io/k8scsi/csi-provisioner:latest
-
-          git clone https://github.com/kubernetes-csi/external-attacher ${GOPATH}/src/github.com/kubernetes-csi/external-attacher
-          make -C ${GOPATH}/src/github.com/kubernetes-csi/external-attacher container
-          docker tag csi-attacher:latest docker.io/k8scsi/csi-attacher:latest
-
-          git clone https://github.com/kubernetes-csi/driver-registrar ${GOPATH}/src/github.com/kubernetes-csi/driver-registrar
-          make -C ${GOPATH}/src/github.com/kubernetes-csi/driver-registrar container
-          docker tag quay.io/k8scsi/driver-registrar:canary docker.io/k8scsi/driver-registrar:latest
-
           # Replace custom cloud config
           {
               cloud_cfg=$(base64 -w 0 ${CLOUD_CONFIG})


### PR DESCRIPTION
Currently the `cloud-provider-openstack-acceptance-test-csi-cinder` job in https://github.com/kubernetes/cloud-provider-openstack fails (see: https://github.com/kubernetes/cloud-provider-openstack/pull/430 + logs: http://logs.openlabtesting.org/logs/30/430/044b09b3d0d07fcb43a678a9e30c8dfb48c68c97/cloud-provider-openstack-acceptance-test-csi-cinder/cloud-provider-openstack-acceptance-test-csi-cinder/e8e2df9/job-output.txt.gz just search for `Error response from daemon: No such image: quay.io/k8scsi/csi-attacher:canary`)

Running the `make` command like in the Zuul job creates an `csi-attacher:latest` image like defined here: https://github.com/kubernetes-csi/external-attacher/blob/master/release-tools/build.make#L68 probably it would be a good idea to pin the version of the tools (e.g. csi-attacher)?