### PR TITLE
Correct sed expression to match only cloud.conf in csi e2e test

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
@@ -113,7 +113,7 @@
           # Replace custom cloud config
           {
               cloud_cfg=$(base64 -w 0 ${CLOUD_CONFIG})
-              sed "s/cloud.conf.*$/cloud.conf: $cloud_cfg/g" -i manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml
+              sed "s/cloud\.conf:.*$/cloud.conf: $cloud_cfg/g" -i manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml
           } > /dev/null 2>&1
 
           # Enable services


### PR DESCRIPTION
The current sed expression `cloud.conf` was to "greedy" and matched for example also `cloud-config` which leads to an error: http://logs.openlabtesting.org/logs/34/434/175ee1955b3c4ac1741013c9cadb39fbc6117fe4/cloud-provider-openstack-acceptance-test-csi-cinder/cloud-provider-openstack-acceptance-test-csi-cinder/46ea07f/job-output.txt.gz (grep for `error parsing manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml`).

The reason for the failure was the sed expression which matched more than only `cloud.conf:`:

Without the fix:

```bash
sed "s/cloud.conf.*$/cloud.conf: $cloud_cfg/g"  manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml
# This YAML file contains secret objects,
# which are necessary to run csi cinder plugin.

kind: Secret
apiVersion: v1
metadata:
  name: cloud.conf: W0dsb2JhbF0KcmVnaW9uPVJlZ2lvbk9uZQp1c2VybmFtZT1hZG1pbgpwYXNzd29yZD1wYXNzdzByZAphdXRoLXVybD1odHRwOi8vMTkyLjEyOC4xLjE1OjUwMDAvdjMKdGVuYW50LWlkPTBkYjIyODA5MTg3OTQzMTdhZWVhNjk3ZjRiMDIyNzgzCmRvbWFpbi1pZD0yOTgyNTAyNzk3MWM0MmY4ODY2YTIyMzU3NGFmMjNkMAoKW0xvYWRCYWxhbmNlcl0Kc3VibmV0LWlkPTljMDE4ODE0LWYyYTgtNDVkZC05Njc5LTU0MDBkNDliMzMzYQpmbG9hdGluZy1uZXR3b3JrLWlkPTgwYzlmYzc4LWEyYmUtNDVkNS1hODViLWYxN2E2Yzk4ZGY5MgoKW0Jsb2NrU3RvcmFnZV0KYnMtdmVyc2lvbj12MgoKW05ldHdvcmtpbmddCnB1YmxpYy1uZXR3b3JrLW5hbWU9cHVibGljCmlwdjYtc3VwcG9ydC1kaXNhYmxlZD1mYWxzZQ==
  namespace: kube-system
data:
  cloud.conf: W0dsb2JhbF0KcmVnaW9uPVJlZ2lvbk9uZQp1c2VybmFtZT1hZG1pbgpwYXNzd29yZD1wYXNzdzByZAphdXRoLXVybD1odHRwOi8vMTkyLjEyOC4xLjE1OjUwMDAvdjMKdGVuYW50LWlkPTBkYjIyODA5MTg3OTQzMTdhZWVhNjk3ZjRiMDIyNzgzCmRvbWFpbi1pZD0yOTgyNTAyNzk3MWM0MmY4ODY2YTIyMzU3NGFmMjNkMAoKW0xvYWRCYWxhbmNlcl0Kc3VibmV0LWlkPTljMDE4ODE0LWYyYTgtNDVkZC05Njc5LTU0MDBkNDliMzMzYQpmbG9hdGluZy1uZXR3b3JrLWlkPTgwYzlmYzc4LWEyYmUtNDVkNS1hODViLWYxN2E2Yzk4ZGY5MgoKW0Jsb2NrU3RvcmFnZV0KYnMtdmVyc2lvbj12MgoKW05ldHdvcmtpbmddCnB1YmxpYy1uZXR3b3JrLW5hbWU9cHVibGljCmlwdjYtc3VwcG9ydC1kaXNhYmxlZD1mYWxzZQ==
```

With the fix:

```bash
sed "s/cloud\.conf.*$/cloud.conf: $cloud_cfg/g" manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml
# This YAML file contains secret objects,
# which are necessary to run csi cinder plugin.

kind: Secret
apiVersion: v1
metadata:
  name: cloud-config
  namespace: kube-system
data:
  cloud.conf: W0dsb2JhbF0KcmVnaW9uPVJlZ2lvbk9uZQp1c2VybmFtZT1hZG1pbgpwYXNzd29yZD1wYXNzdzByZAphdXRoLXVybD1odHRwOi8vMTkyLjEyOC4xLjE1OjUwMDAvdjMKdGVuYW50LWlkPTBkYjIyODA5MTg3OTQzMTdhZWVhNjk3ZjRiMDIyNzgzCmRvbWFpbi1pZD0yOTgyNTAyNzk3MWM0MmY4ODY2YTIyMzU3NGFmMjNkMAoKW0xvYWRCYWxhbmNlcl0Kc3VibmV0LWlkPTljMDE4ODE0LWYyYTgtNDVkZC05Njc5LTU0MDBkNDliMzMzYQpmbG9hdGluZy1uZXR3b3JrLWlkPTgwYzlmYzc4LWEyYmUtNDVkNS1hODViLWYxN2E2Yzk4ZGY5MgoKW0Jsb2NrU3RvcmFnZV0KYnMtdmVyc2lvbj12MgoKW05ldHdvcmtpbmddCnB1YmxpYy1uZXR3b3JrLW5hbWU9cHVibGljCmlwdjYtc3VwcG9ydC1kaXNhYmxlZD1mYWxzZQ==
```

and this was the initial `manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml`:

```yaml
# This YAML file contains secret objects,
# which are necessary to run csi cinder plugin.

kind: Secret
apiVersion: v1
metadata:
  name: cloud-config
  namespace: kube-system
data:
  cloud.conf: W0dsb2JhbF0KdXNlcm5hbWU9dXNlcgpwYXNzd29yZD1wYXNzCmF1dGgtdXJsPWh0dHBzOi8vPGtleXN0b25lX2lwPi9pZGVudGl0eS92Mwp0ZW5hbnQtaWQ9Yzg2OTE2OGE4Mjg4NDdmMzlmN2YwNmVkZDczMDU2MzcKZG9tYWluLWlkPTJhNzNiOGY1OTdjMDQ1NTFhMGZkYzhlOTU1NDRiZThhCg==

```