### PR TITLE
Fix ansible-lint 601 error

### DIFF
--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -25,7 +25,7 @@
       EOF
     executable: /bin/bash
   when:
-    - DISABLE_HTTPD_MOD_WSGI|default(false)|bool == true
+    - DISABLE_HTTPD_MOD_WSGI|default(false)|bool
 
 # Populate local conf with heat service enabled
 - name: create devstack local conf with Heat enabled

--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -15,7 +15,7 @@
           sed -i "/KEYSTONE_SERVICE_URI=/ s|/identity|:5000|" /opt/stack/new/devstack/lib/keystone' '{{ ansible_user_dir }}/workspace/devstack-gate/devstack-vm-gate-wrap.sh'
     executable: /bin/bash
   when:
-    - DISABLE_HTTPD_MOD_WSGI|default(false)|bool == true
+    - DISABLE_HTTPD_MOD_WSGI|default(false)|bool
 
 - name: Install libpcre3-dev
   shell: |


### PR DESCRIPTION
Fix ansible-lint 601 error don't compare to literal
ture/false.