### PR TITLE
update cloud-provider-openstack tests to use block storage v3

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
@@ -28,7 +28,7 @@
           username = $OS_USERNAME
           region = $OS_REGION_NAME
           [BlockStorage]
-          bs-version = v2
+          bs-version = v3
           ignore-volume-az = yes
           EOF
 

--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -29,7 +29,7 @@
           region = $OS_REGION_NAME
 
           [BlockStorage]
-          bs-version = v2
+          bs-version = v3
           ignore-volume-az = yes
           EOF
 

--- a/playbooks/cloud-provider-openstack-acceptance-test-flexvolume-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-flexvolume-cinder/run.yaml
@@ -40,7 +40,7 @@
           region = $OS_REGION_NAME
 
           [BlockStorage]
-          bs-version = v2
+          bs-version = v3
           ignore-volume-az = yes
           EOF
 

--- a/playbooks/cloud-provider-openstack-acceptance-test-k8s-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-k8s-cinder/run.yaml
@@ -29,7 +29,7 @@
           region = $OS_REGION_NAME
 
           [BlockStorage]
-          bs-version = v2
+          bs-version = v3
           ignore-volume-az = yes
           EOF
 

--- a/playbooks/cloud-provider-openstack-acceptance-test-keystone-authentication-authorization/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-keystone-authentication-authorization/run.yaml
@@ -33,7 +33,7 @@
           region = $OS_REGION_NAME
 
           [BlockStorage]
-          bs-version = v2
+          bs-version = v3
           ignore-volume-az = yes
           EOF
 

--- a/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
@@ -35,7 +35,7 @@
           floating-network-id = $(openstack network list --external -f value -c ID | head -n 1)
           subnet-id = $(openstack network list --internal -f value -c Subnets | head -n 1)
           [BlockStorage]
-          bs-version = v2
+          bs-version = v3
           ignore-volume-az = yes
           EOF
 

--- a/playbooks/cloud-provider-openstack-acceptance-test-standalone-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-standalone-cinder/run.yaml
@@ -30,7 +30,7 @@
           region = $OS_REGION_NAME
 
           [BlockStorage]
-          bs-version = v2
+          bs-version = v3
           ignore-volume-az = yes
           EOF
 


### PR DESCRIPTION
Currently, all the cloud-provider-openstack tests use block storage
version v2 which is deprecated. This commit updates to use latest
version v3 instead.