### PR TITLE
Fix devstack trove deploying failed

### DIFF
--- a/playbooks/terraform-provider-openstack-acceptance-test-trove/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-trove/run.yaml
@@ -26,9 +26,13 @@
         cmd: |
           set -e
           set -x
-          cd /opt/stack/trove/integration/scripts/
-          ./trovestack install
-          ./trovestack kick-start mysql
+          export BRIDGE_IP=10.1.0.1
+          export DEST='/opt/stack'
+          export PATH_DEVSTACK_SRC=$DEST/devstack
+          export TROVE_RESIZE_TIME_OUT=''
+          cd $DEST/trove
+          tox -etrovestack -vv -- install
+          tox -etrovestack -vv -- kick-start mysql
           source /home/zuul/devstack/openrc admin admin
 
           # Following commands show some info for debugging

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -128,7 +128,6 @@
     description: |
       Run terraform-provider-openstack trove acceptance test on master branch
     run: playbooks/terraform-provider-openstack-acceptance-test-trove/run.yaml
-    nodeset: ubuntu-xenial-otc
 
 - job:
     name: terraform-provider-openstack-acceptance-test-lbaas

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -31,12 +31,6 @@
         label: ubuntu-bionic-vxh-arm64
 
 - nodeset:
-    name: ubuntu-xenial-otc
-    nodes:
-      - name: ubuntu-xenial-otc
-        label: ubuntu-xenial-otc
-
-- nodeset:
     name: ubuntu-xenial-huaweicloud
     nodes:
       - name: ubuntu-xenial-huaweicloud


### PR DESCRIPTION
- OpenStack upstream have used tox to deploy trove in python3,
  OpenLab keep to use same way to do it.
- OpenStack CI use 4 vCPUs and 8G RAM instances to run trove integration
  tests, OpenLab should be able to use same falvor, so remove nodepool
  label `ubuntu-xenial-otc`.

Closes: theopenlab/openlab#183