### PR TITLE
Fix error of running trovestack in openlab job

### DIFF
--- a/playbooks/terraform-provider-openstack-acceptance-test-trove/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-trove/run.yaml
@@ -17,6 +17,7 @@
           export PATH_DEVSTACK_SRC=$DEST/devstack
           export TROVE_RESIZE_TIME_OUT=''
           cd $DEST/trove
+          sed -i 's/-c\/opt\/stack\/trove\/test-upper-constraints.txt/{toxinidir}\/test-upper-constraints.txt/' tox.ini
           tox -etrovestack -vv -- kick-start mysql
           source /home/zuul/devstack/openrc admin admin
 


### PR DESCRIPTION
Change directory of trove to {toxinidir} for
testenv trovestack in /trove/tox.ini.

Related-Bug: theopenlab/openlab#183