### PR TITLE
Fix trove job errors

### DIFF
--- a/playbooks/terraform-provider-openstack-acceptance-test-trove/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-trove/run.yaml
@@ -6,12 +6,16 @@
       enable_services:
         - 'trove'
     - install-devstack
+
+- hosts: all
   tasks:
     - name:  Install and init trove environment
       shell:
         cmd: |
           set -e
           set -x
+          sudo chown zuul.zuul /opt/stack/ -R
+          sudo chown zuul.zuul /etc/trove/ -R
           export BRIDGE_IP=10.0.0.1
           export DEST='/opt/stack/new'
           export PATH_DEVSTACK_SRC=$DEST/devstack
@@ -19,14 +23,15 @@
           cd $DEST/trove
           sed -i 's/\/opt\/stack\/trove\/test-upper-constraints.txt/{toxinidir}\/test-upper-constraints.txt/' tox.ini
           tox -etrovestack -vv -- kick-start mysql
-          source /home/zuul/devstack/openrc admin admin
+          source $PATH_DEVSTACK_SRC/openrc admin admin
 
           # Following commands show some info for debugging
           trove datastore-list
           openstack image list
-          openstack image show ubuntu_mysql
+          openstack image show ubuntu-mysql-5.7
           trove flavor-list
           df -h
+
         executable: /bin/bash
         chdir: '{{ ansible_user_dir }}/workspace'
       environment: '{{ zuul | zuul_legacy_vars }}'
@@ -42,7 +47,9 @@
           set -e
           set -o pipefail
           set -x
-          pushd /home/zuul/devstack
+          export DEST='/opt/stack/new'
+          export PATH_DEVSTACK_SRC=$DEST/devstack
+          pushd $PATH_DEVSTACK_SRC
           source openrc admin admin
           openstack flavor create m1.acctest --id 99 --ram 512 --disk 5 --vcpu 1 --ephemeral 10
           openstack flavor create m1.resize --id 98 --ram 512 --disk 6 --vcpu 1 --ephemeral 10


### PR DESCRIPTION
Fix trove job errors with several changes:
1. trovestack scripts can not run as root
2. change path of devstack src to /opt/stack/new/devstack
3. change dest path of trove to /opt/stack/new/trove
4. change owner of files in directory of /opt/stack
   and /etc/trove to support running tox -etrovestack
5. there is an error of trove upstream when exec tox -etrovestack,
   which hard code of /opt/stack/trove/test-upper-constraints.txt
   in tox.ini, change it to
   {toxinidir}/stack/trove/test-upper-constraints.txt

Closes: theopenlab/openlab#183