### PR TITLE
Fix local.conf for Ironic

### DIFF
--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -273,8 +273,8 @@
       set -x
       cat << EOF >> /tmp/dg-local.conf
       enable_plugin ironic https://git.openstack.org/openstack/ironic
-      DEFAULT_INSTANCE_TYPE: baremetal
-      OVERRIDE_PUBLIC_BRIDGE_MTU: 1400
+      DEFAULT_INSTANCE_TYPE=baremetal
+      OVERRIDE_PUBLIC_BRIDGE_MTU=1400
       VIRT_DRIVER=ironic
       BUILD_TIMEOUT=720
       IRONIC_BAREMETAL_BASIC_OPS=True
@@ -291,11 +291,9 @@
       IRONIC_VM_LOG_DIR=/opt/stack/new/ironic-bm-logs
       IRONIC_VM_SPECS_RAM=384
       IRONIC_DEFAULT_DEPLOY_INTERFACE=direct
-      IRONIC_ENABLED_DEPLOY_INTERFACES=iscsi,direct,ansible
+      IRONIC_ENABLED_DEPLOY_INTERFACES=iscsi,direct
       SWIFT_ENABLE_TEMPURLS=True
       SWIFT_TEMPURL_KEY=secretkey
-      Q_AGENT=openvswitch
-      Q_ML2_TENANT_NETWORK_TYPE=vxlan
       EOF
     executable: /bin/bash
   when:


### PR DESCRIPTION
This PR fixes some problems in the generated `local.conf` when Ironic is enabled 
The problems were found while trying to setup in the gophercloud repository, based on the local.conf generated some tests were executed in DevStack  and the following changes are necessary:
- Change `:` to `=` DEFAULT_INSTANCE_TYPE and DEFAULT_INSTANCE_TYPE
- Remove `Q_AGENT` and `Q_ML2_TENANT_NETWORK_TYPE`
- Remove `ansible` from `IRONIC_ENABLED_DEPLOY_INTERFACES`

Closes: theopenlab/openlab#205