### PR TITLE
Remove FEATURE_GATES variable

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
@@ -64,7 +64,6 @@
           export MAX_TIME_FOR_URL_API_SERVER=5
 
           # Requirements to deploy the csi cinder driver
-          export FEATURE_GATES="CSIPersistentVolume=true,MountPropagation=true"
           export RUNTIME_CONFIG="storage.k8s.io/v1alpha1=true"
 
           # -E preserves the current env vars, but we need to special case PATH


### PR DESCRIPTION
Both variables are in GA (since 1.13/1.12) and no longer required, see: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates. with the Feature gates still provided the test will fail always since the API server doesn't come up: http://logs.openlabtesting.org/logs/20/520/18b453d905868ac448a664b7c897edac4e680532/cloud-provider-openstack-acceptance-test-csi-cinder/cloud-provider-openstack-acceptance-test-csi-cinder/7b6f0b5/logs/kubernetes/kube-apiserver.log


```bash
W0305 06:26:38.152427    9523 feature_gate.go:218] Setting GA feature gate CSIPersistentVolume=true. It will be removed in a future release.
Error: invalid argument "CSIPersistentVolume=true,MountPropagation=true" for "--feature-gates" flag: unrecognized feature gate: MountPropagation
Usage:
  hyperkube kube-apiserver [flags]
```