### PR TITLE
Fix trove job errors

### DIFF
--- a/playbooks/terraform-provider-openstack-acceptance-test-trove/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-trove/run.yaml
@@ -14,7 +14,7 @@
         cmd: |
           set -e
           set -x
-          sudo chown zuul.zuul /opt/stack/ -R
+          sudo chown zuul.zuul /opt/stack/new/trove/ -R
           sudo chown zuul.zuul /etc/trove/ -R
           export BRIDGE_IP=10.0.0.1
           export DEST='/opt/stack/new'
@@ -28,7 +28,6 @@
           # Following commands show some info for debugging
           trove datastore-list
           openstack image list
-          openstack image show ubuntu-mysql-5.7
           trove flavor-list
           df -h
 

--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -51,6 +51,7 @@
       enable_plugin trove git://git.openstack.org/openstack/trove
       PATH_TROVE="/opt/stack/new/trove"
       TROVESTACK_SCRIPTS="/opt/stack/new/trove/integration/scripts"
+      SSH_DIR="/opt/stack/new/.ssh"
       EOF
     executable: /bin/bash
   when:


### PR DESCRIPTION
This change is the modification of last fixing
with several changes:
1. trove-guest uses ssh keypairs to communicate with
tr-manager,so specify the correct path to generate the
ssh keypairs.
2. only change owner of files in directory of /opt/stack/new/trove
   and /etc/trove to support running tox -etrovestack.

Closes: theopenlab/openlab#183