### PR TITLE
Add helm charts integration test with k8s

### DIFF
--- a/playbooks/helm-integration-test-kubeadm-k8s/run.yaml
+++ b/playbooks/helm-integration-test-kubeadm-k8s/run.yaml
@@ -1,0 +1,66 @@
+- hosts: all
+  become: yes
+  roles:
+    - role: create-single-k8s-cluster-with-kubeadm
+      docker_vcgroupdriver: "cgroupfs"
+  tasks:
+    - name: Run integration tests of Helm deployed on k8s cluster
+      shell:
+        cmd: |
+          set -ex
+
+          # we use chart-testing docker image latest (now is v2.2.0) to run tests
+          docker run --rm --interactive --detach --network host --name ctd \
+                  --volume "$(pwd)/test/ct.yaml:/etc/ct/ct.yaml" \
+                  --volume "$(pwd):/workdir" \
+                  --workdir /workdir \
+                  "quay.io/helmpack/chart-testing:{{ chart_testing_version }}"
+          trap "docker container rm --force ctd > /dev/null" EXIT
+          # copy the config file into test container
+          docker cp "$HOME/.kube" "ctd:/root/.kube"
+
+          # debug the cluster info
+          docker exec --interactive ctd "$@" kubectl cluster-info
+
+          # Create service account tiller and bind the right role
+          docker exec --interactive ctd "$@" kubectl --namespace kube-system create sa tiller
+          docker exec --interactive ctd "$@" kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
+
+          # helm client has installed in chart-testing image, here we install the helm server tiller
+          docker exec --interactive ctd "$@" helm init --service-account tiller
+          # sleep 3 minutes to wait the tiller pod become running
+          sleep 180
+          # we need to test databases like mysql installing, persistence is enabled default,
+          # create local pv to support the test
+          mkdir /home/zuul/k8s/
+          cat << EOF >> /home/zuul/k8s/local-pv.yaml
+          apiVersion: v1
+          kind: PersistentVolume
+          metadata:
+            name: local-pv
+            namespace: kube-system
+          spec:
+            capacity:
+              storage: 10Gi
+            accessModes:
+              - ReadWriteOnce
+            persistentVolumeReclaimPolicy: Recycle
+            hostPath:
+              path: /home/zuul/k8s
+          EOF
+
+          kubectl create -f /home/zuul/k8s/local-pv.yaml
+          kubectl get pv
+
+          # the default value of remote is k8s of test/ct.yaml of charts repo, so add the k8s remote, otherwise
+          # lint will fail
+          docker exec --interactive ctd "$@" git remote add k8s https://github.com/helm/charts
+          docker exec --interactive ctd "$@" git fetch k8s
+
+          # run cmd "ct lint-and-install" to test several charts
+          docker exec --interactive ctd "$@" ct lint-and-install --charts stable/mysql,stable/postgresql,stable/etcd-operator,stable/coredns --namespace kube-system
+          # some charts won't delete the pvc, delete them manually to make sure pv is available
+          kubectl delete pvc --all --namespace kube-system
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
+      environment: '{{ global_env }}'

--- a/roles/create-single-k8s-cluster-with-kubeadm/defaults/main.yaml
+++ b/roles/create-single-k8s-cluster-with-kubeadm/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+kubernetes_version: "latest"

--- a/roles/create-single-k8s-cluster-with-kubeadm/tasks/main.yml
+++ b/roles/create-single-k8s-cluster-with-kubeadm/tasks/main.yml
@@ -17,7 +17,14 @@
       EOF
 
       apt-get update
-      apt-get install -y kubelet kubeadm kubectl
+      if [[ "{{ kubernetes_version }}" == "latest" ]]; then
+          apt-get install -y kubelet kubeadm kubectl
+      else
+          install_version=$(apt-cache madison kubelet |grep "{{ kubernetes_version }}" | head -n 1 | awk '{print $3}')
+          apt-get install -y kubelet=$install_version kubeadm=$install_version kubectl=$install_version
+      fi
+
+      kubelet --version
       apt-mark hold kubelet kubeadm kubectl
 
       # Creating a single master cluster with kubeadm:
@@ -27,9 +34,10 @@
       cat /etc/resolv.conf
 
       ## Initializing master
-      kubeadm init --pod-network-cidr=192.168.0.0/16
+      kubeadm init --pod-network-cidr=192.168.0.0/16 --kubernetes-version="{{ kubernetes_version }}"
 
-      export KUBECONFIG=/etc/kubernetes/admin.conf
+      mkdir -p $HOME/.kube
+      sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
 
       ## Installing a pod network add-on.
       kubectl apply -f https://docs.projectcalico.org/v3.3/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1114,3 +1114,24 @@
       Run integration tests of Kubernetes IN Docker against ARM64 architecture
     run: playbooks/kind-integration-test-arm64/run.yaml
     nodeset: ubuntu-xenial-arm64
+
+- job:
+    name: helm-integration-test-kubeadm-k8s-v1.14.0
+    parent: init-test
+    description: |
+      Run integration tests of helm charts with v1.14.0 k8s cluster deployed by kubeadm, and using docker image of v2.2.0 chart-testing tool which installed with helm v2.12.2
+    run: playbooks/helm-integration-test-kubeadm-k8s/run.yaml
+    vars:
+      chart_testing_version: v2.2.0
+      kubernetes_version: 1.14.0
+
+- job:
+    name: helm-integration-test-kubeadm-k8s-v1.12.7
+    parent: init-test
+    description: |
+      Run integration tests of helm charts with v1.12.7 k8s cluster deployed by kubeadm, and using docker image of v2.2.0 chart-testing tool which installed with helm v2.12.2
+    run: playbooks/helm-integration-test-kubeadm-k8s/run.yaml
+    vars:
+      chart_testing_version: v2.2.0
+      kubernetes_version: 1.12.7
+      docker_ce_version: 18.06

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -29,6 +29,7 @@
             branches: stable-2.7
         - openstacksdk-ansible-devel-functional-devstack:
             branches: devel
+
 - project:
     name: apache/spark
     periodic-0/12:
@@ -60,6 +61,15 @@
     periodic-2/14:
       jobs:
         - terraform-provider-huaweicloud-acceptance-test-fusioncloud:
+            branches: master
+
+- project:
+    name: helm/charts
+    periodic-2/14:
+      jobs:
+        - helm-integration-test-kubeadm-k8s-v1.14.0:
+            branches: master
+        - helm-integration-test-kubeadm-k8s-v1.12.7:
             branches: master
 
 ####################### periodic jobs on 04:00/16:00 ##########################


### PR DESCRIPTION
Add two periodic job of helm charts integration test
with k8s v1.14.0 and v1.12.7 versions

We will add two jobs of integration test of helm with native k8s cluster which use latest version chart-testing tool:
1. helm with 2.12.2 and kubernetes with v1.14.0
2. helm with 2.12.2 and kubernetes with v1.12.7

Closes: theopenlab/openlab#212