### PR TITLE
Remove enable_services of designate devstack conf

### DIFF
--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -159,7 +159,6 @@
       set -e
       set -x
       cat << EOF >> /tmp/dg-local.conf
-      enable_service designate,designate-central,designate-api,designate-pool-manager,designate-zone-manager,designate-mdns
       enable_plugin designate git://git.openstack.org/openstack/designate
       EOF
     executable: /bin/bash


### PR DESCRIPTION
Fix devstack install error if enable designate

There is an error happened when installing devstack enabled designate:
ERROR designate.cmd.pool_manager [-] You have designate-worker enabled, starting designate-pool-manager is incompatible with designate-worker. You need to start designate-worker instead.

Related-Bug: theopenlab/openlab#216