### PR TITLE
Support kubernetes version for minikube start

### DIFF
--- a/roles/create-single-k8s-cluster-with-minikube/defaults/main.yaml
+++ b/roles/create-single-k8s-cluster-with-minikube/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-minikube_version: "v0.30.0"
-kubectl_version: "v1.10.0"
+minikube_version: "latest"
+kubernetes_version: "latest"

--- a/roles/create-single-k8s-cluster-with-minikube/tasks/main.yml
+++ b/roles/create-single-k8s-cluster-with-minikube/tasks/main.yml
@@ -1,12 +1,16 @@
 - name: Create a single k8s master cluster by minikube
   shell: |
     set -ex
-    # Download minikube binary, the supported latest version is v0.30.0
+    # Download minikube binary
     curl -Lo /usr/local/bin/minikube https://storage.googleapis.com/minikube/releases/"{{ minikube_version }}"/minikube-linux-amd64 && chmod +x /usr/local/bin/minikube
     # Download kubectl binary
-    curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/"{{ kubectl_version }}"/bin/linux/amd64/kubectl && chmod +x /usr/local/bin/kubectl
+    curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/"{{ kubernetes_version }}"/bin/linux/amd64/kubectl && chmod +x /usr/local/bin/kubectl
     sed -i 's/nameserver 127.0.0.1/nameserver 8.8.8.8/' /etc/resolv.conf
-    minikube start --cpus 4 --memory 6144 --vm-driver=none
+    if [[ "{{ kubernetes_version }}" == "latest" ]]; then
+        minikube start --cpus 4 --memory 6144 --vm-driver=none
+    else
+        minikube start --cpus 4 --memory 6144 --vm-driver=none --kubernetes-version {{ kubernetes_version }}
+    fi
     # sleep for waiting cluster ready
     sleep 180
     timeout 300 bash -c '

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1089,23 +1089,28 @@
       - orange_credentials
 
 - job:
-    name: spark-integration-test-kubeadm-k8s
+    name: spark-integration-test-kubeadm-k8s-v1.14.0
     parent: init-test
     description: |
-      Run integration tests of spark of master with k8s cluster deployed by kubeadm
+      Run integration tests of spark of master against with v1.14.0 k8s cluster deployed by kubeadm
     run: playbooks/spark-integration-test-kubeadm-k8s/run.yaml
     vars:
       k8s_log_dir: '{{ ansible_user_dir }}/workspace/logs/kubernetes'
+      kubernetes_version: 1.14.0
 
 - job:
-    name: spark-integration-test-minikube-k8s
+    name: spark-integration-test-minikube-k8s-v1.10.0
     parent: init-test
     description: |
-      Run integration tests of spark of v2.4.0 with k8s cluster deployed by minikube
+      Run integration tests of spark of v2.4.0 against with v1.10.0 k8s cluster deployed by v0.30.0 minikube
     run: playbooks/spark-integration-test-minikube-k8s/run.yaml
     override-checkout: branch-2.4
     vars:
       k8s_log_dir: '{{ ansible_user_dir }}/workspace/logs/kubernetes'
+      # the supported latest version of minikube is v0.30.0, and then the minikube can start
+      # k8s in v1.10.0
+      minikube_version: v0.30.0
+      kubernetes_version: v1.10.0
 
 - job:
     name: kind-integration-test-arm64

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -34,9 +34,9 @@
     name: apache/spark
     periodic-0/12:
       jobs:
-        - spark-integration-test-kubeadm-k8s:
+        - spark-integration-test-kubeadm-k8s-v1.14.0:
             branches: master
-        - spark-integration-test-minikube-k8s:
+        - spark-integration-test-minikube-k8s-v1.10.0:
             branches: master
             
 - project:


### PR DESCRIPTION
Add a parameter "kubernetes_version" for
role create-single-k8s-cluster-with-minikube to
support specify k8s version if needed.

Related: theopenlab/openlab#213