### PR TITLE
Fix PR#222 for increase swift device size

### DIFF
--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -8,6 +8,7 @@
       [[local|localrc]]
       NETWORK_GATEWAY=10.0.0.1
       enable_plugin neutron git://git.openstack.org/openstack/neutron
+      SWIFT_LOOPBACK_DISK_SIZE=10G
       EOF
     executable: /bin/bash
 


### PR DESCRIPTION
This patch fixes the issue mentioned in PR#222.

The default size of devstack swift is 2G, if we enable octavia or we
create some new images into glance during test. We will get failure.
The key reason for this is the swift device size is too small. So this
patch will increase the size through pass a env parameter in devstack
local conf.

Close: theopenlab/openlab#222