### PR TITLE
Remove unneeded workaround for default sg of fusioncloud

### DIFF
--- a/playbooks/terraform-provider-huaweicloud-acceptance-test-fusioncloud/run.yaml
+++ b/playbooks/terraform-provider-huaweicloud-acceptance-test-fusioncloud/run.yaml
@@ -50,8 +50,6 @@
           # can only set one of OS_DOMAIN_ID and OS_DOMAIN_NAME
           unset OS_DOMAIN_ID
 
-          # workaround, see terraform-providers/terraform-provider-huaweicloud#50
-          sed -i s/Sys-default/default/ huaweicloud/resource_huaweicloud_compute_instance_v2.go
           # workaround, disable AK/SK auth to use token auth instead
           unset OS_ACCESS_KEY
           unset OS_SECRET_KEY


### PR DESCRIPTION
This removes the default security group workaround as the issue has been addressed on terraform-provider-huaweicloud.