### PR TITLE
Comment out bazel related roles

### DIFF
--- a/playbooks/kind-integration-test-arm64/run.yaml
+++ b/playbooks/kind-integration-test-arm64/run.yaml
@@ -6,8 +6,8 @@
       go_version: 1.12
     - role: install-docker-ce
       arch: arm64
-    - role: andrewrothstein.bazel
-      bazel_ver: '0.23.1'
+    #- role: andrewrothstein.bazel
+    #  bazel_ver: '0.23.1'
 
   tasks:
     - name: git required repositories


### PR DESCRIPTION
Comment out bazel related roles, we use cloud image for KinD test, 
previously the job fails because of bazel installation, the cloud image
uploaded included a successfuly built bazel. lets skip the bazel 
installation and make the job running first. We can refactor the bazel
role latter if required.

Related: theopenlab/openlab#230