### PR TITLE
change http to https in log link

### DIFF
--- a/playbooks/base/post-logs.yaml
+++ b/playbooks/base/post-logs.yaml
@@ -10,4 +10,4 @@
     - role: upload-logs
       # NOTE: because we use same host for zuul status and logs server, added
       # a '/logs' suffix for the convenience to routing request
-      zuul_log_url: "http://logs.openlabtesting.org/logs"
+      zuul_log_url: "https://logs.openlabtesting.org/logs"


### PR DESCRIPTION
After https://github.com/theopenlab/openlab/issues/202 merged, we can change this to 'https'.