### PR TITLE
[Issue #196]Enable GPU AI job

### DIFF
--- a/roles/create-ai-environment/tasks/main.yaml
+++ b/roles/create-ai-environment/tasks/main.yaml
@@ -132,35 +132,6 @@
 
     executable: /bin/bash
 
-- name: Prepare GPU env (GPU driver and CUDA)
-  when: is_gpu_enabled and nodepool.cloud != 'huaweicloud'
-  shell:
-    cmd: |
-      set -xe
-      apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub
-      wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_9.1.85-1_amd64.deb
-      cd /var/
-      apt purge -y cuda*
-      apt-get remove -y --purge nvidia-418 nvidia-modprobe nvidia-settings
-      cd -
-      apt install -y ./cuda-repo-ubuntu1604_9.1.85-1_amd64.deb
-      wget http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1604/x86_64/nvidia-machine-learning-repo-ubuntu1604_1.0.0-1_amd64.deb
-      apt install -y ./nvidia-machine-learning-repo-ubuntu1604_1.0.0-1_amd64.deb
-      apt update
-      apt install -y cuda9.0 cuda-cublas-9-0 cuda-cufft-9-0 cuda-curand-9-0 cuda-cusolver-9-0 cuda-cusparse-9-0 libcudnn7=7.2.1.38-1+cuda9.0 libnccl2=2.2.13-1+cuda9.0 cuda-command-line-tools-9-0
-      apt install -y linux-headers-$(uname -r)
-
-      # Remember install the latest nvidia driver if the linux kernel version is new
-      # This is for Tesla P100 GPU driver
-      wget http://us.download.nvidia.com/tesla/418.40.04/NVIDIA-Linux-x86_64-418.40.04.run
-      chmod +x ./NVIDIA-Linux-x86_64-418.40.04.run
-      cat > 'input' <<EOF
-      yes
-      yes
-      EOF
-      ./NVIDIA-Linux-x86_64-418.40.04.run -a --ui=none < ./input
-    executable: /bin/bash
-
 - name: Install {{ user_meta.framework.name }}-{{ user_meta.framework.version }}
   when:
     ( user_meta.framework.name == "tensorflow" and runtime_name.stdout in ["python", "c", "java", "go"] ) or

--- a/roles/create-ai-environment/tasks/main.yaml
+++ b/roles/create-ai-environment/tasks/main.yaml
@@ -133,7 +133,7 @@
     executable: /bin/bash
 
 - name: Prepare GPU env (GPU driver and CUDA)
-  when: is_gpu_enabled
+  when: is_gpu_enabled and nodepool.cloud != 'huaweicloud'
   shell:
     cmd: |
       set -xe
@@ -148,14 +148,17 @@
       apt install -y ./nvidia-machine-learning-repo-ubuntu1604_1.0.0-1_amd64.deb
       apt update
       apt install -y cuda9.0 cuda-cublas-9-0 cuda-cufft-9-0 cuda-curand-9-0 cuda-cusolver-9-0 cuda-cusparse-9-0 libcudnn7=7.2.1.38-1+cuda9.0 libnccl2=2.2.13-1+cuda9.0 cuda-command-line-tools-9-0
-      apt install -y linux-headers-4.4.0-142-generic
-      wget http://us.download.nvidia.com/tesla/384.81/NVIDIA-Linux-x86_64-384.81.run
-      chmod +x ./NVIDIA-Linux-x86_64-384.81.run
+      apt install -y linux-headers-$(uname -r)
+
+      # Remember install the latest nvidia driver if the linux kernel version is new
+      # This is for Tesla P100 GPU driver
+      wget http://us.download.nvidia.com/tesla/418.40.04/NVIDIA-Linux-x86_64-418.40.04.run
+      chmod +x ./NVIDIA-Linux-x86_64-418.40.04.run
       cat > 'input' <<EOF
       yes
       yes
       EOF
-      ./NVIDIA-Linux-x86_64-384.81.run -a --ui=none < ./input
+      ./NVIDIA-Linux-x86_64-418.40.04.run -a --ui=none < ./input
     executable: /bin/bash
 
 - name: Install {{ user_meta.framework.name }}-{{ user_meta.framework.version }}

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -16,10 +16,10 @@
       jobs:
         - ai-on-openlab-test-vm:
             files:
-              - ^user_data/*.*
+              - ^user_data/.*
         - ai-on-openlab-test-vm-with-gpu:
             files:
-              - ^user_data_gpu/*.*
+              - ^user_data_gpu/.*
 
 ####################### periodic jobs on 00:00/12:00 ##########################
 - project:


### PR DESCRIPTION
This will ignore the CUDA and NVIDIA driver installation when job use
huaweicloud. Now, GPU resources only support Tesla V100 GPU on
huaweicloud with a specific flavor.

Issue link: https://github.com/theopenlab/openlab/issues/196