### PR TITLE
The timeout is too short for KinD tests

### DIFF
--- a/playbooks/kind-integration-test-arm64/run.yaml
+++ b/playbooks/kind-integration-test-arm64/run.yaml
@@ -44,6 +44,6 @@
             --check-version-skew=false \
             --down \
             --test_args="--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\] --num-nodes=3" \
-            --timeout=120m
+            --timeout=240m
         executable: /bin/bash
       environment: '{{ global_env }}'


### PR DESCRIPTION
The timeout is too short for KinD tests according to current test logs:
http://status.openlabtesting.org/builds?job_name=kind-integration-test-arm64
Issue link: https://github.com/theopenlab/openlab/issues/230