### PR TITLE
Fix inference page CORS error

### DIFF
--- a/roles/create-ai-environment/tasks/main.yaml
+++ b/roles/create-ai-environment/tasks/main.yaml
@@ -245,7 +245,7 @@
       mv '{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/css' '{{ result_folder }}/web_page/'
       mv '{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/js' '{{ result_folder }}/web_page/'
 
-      model_path="https:\/\/status.openlabtesting.org\/logs\/{{ zuul.change[-2:] }}\/{{ zuul.change }}\/{{ zuul.patchset }}\/check\/{{ zuul.job }}\/{{ zuul.build[:7] }}\/test_results\/web_page\/tfjs\/model.json"
+      model_path="https:\/\/logs.openlabtesting.org\/logs\/{{ zuul.change[-2:] }}\/{{ zuul.change }}\/{{ zuul.patchset }}\/check\/{{ zuul.job }}\/{{ zuul.build[:7] }}\/test_results\/web_page\/tfjs\/model.json"
       sed -i "s/replace.me/$model_path/" '{{ result_folder }}/web_page/index.html'
     executable: /bin/bash
 


### PR DESCRIPTION
The inference page now is hosted on log server. Set the model url
to be `logs` so that it can follow http CORS rule