### PR TITLE
Refactor for logs and results arch directory.

### DIFF
--- a/playbooks/init-test/pre.yaml
+++ b/playbooks/init-test/pre.yaml
@@ -1,3 +1,3 @@
 - hosts: all
   roles:
-    - ensure-legacy-workspace-directory
+    - prepare-workspace

--- a/roles/config-gcc/defaults/main.yml
+++ b/roles/config-gcc/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+gcc_version: '7'

--- a/roles/config-gcc/tasks/main.yml
+++ b/roles/config-gcc/tasks/main.yml
@@ -1,0 +1,25 @@
+# We can install specify version gcc/g++ in task, like this:
+#- roles:
+#  - role: config-gcc
+#      gcc_version: '7'
+---
+- name: Install gcc and g++
+  shell: |
+    set -ex
+
+    # Install the g++-{{ gcc_version }} packages
+    apt-get install -y software-properties-common
+    add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    apt update || true
+    apt install "g++-{{ gcc_version }}" -y
+
+    # Set it up so the symbolic links gcc, g++ point to the newer version
+    update-alternatives --install /usr/bin/gcc gcc "/usr/bin/gcc-{{ gcc_version }}" 60 \
+                             --slave /usr/bin/g++ g++ "/usr/bin/g++-{{ gcc_version }}"
+    update-alternatives --config gcc
+
+    # print g++ version
+    gcc --version
+    g++ --version
+  args:
+    executable: /bin/bash

--- a/roles/ensure-legacy-workspace-directory/tasks/main.yml
+++ b/roles/ensure-legacy-workspace-directory/tasks/main.yml
@@ -1,4 +1,0 @@
-- name: Ensure legacy workspace directory
-  file:
-    path: '{{ ansible_user_dir }}/workspace'
-    state: directory

--- a/roles/prepare-workspace/tasks/main.yml
+++ b/roles/prepare-workspace/tasks/main.yml
@@ -1,0 +1,26 @@
+- name: Prepare workspace directory
+  file:
+    path: '{{ ansible_user_dir }}/workspace'
+    state: directory
+
+- name: Prepare logs directory
+  file:
+    path: '{{ ansible_user_dir }}/workspace/logs'
+    state: directory
+
+- name: Prepare results directory
+  file:
+    path: '{{ ansible_user_dir }}/workspace/test_results'
+    state: directory
+
+- name: Set workspace env vars
+  set_fact:
+    workspace_env:
+      LOGS_PATH: '{{ ansible_user_dir }}/workspace/logs'
+      RESULTS_PATH: '{{ ansible_user_dir }}/workspace/test_results'
+  no_log: yes
+
+- name: Merge workspace env vars into global env
+  set_fact:
+    global_env: '{{ global_env | combine(workspace_env) }}'
+  no_log: yes


### PR DESCRIPTION
Now we have multiple different custom logs path exist in
different OpenLab jobs.

This patch try to build a consist mechanism and usage in
order to avoiding end user and developer's confusion:

1. Add $LOG_PATH, $RESULT_PATH global env.
2. Prepare the {{ ansible_user_dir }}/workspace/logs,
and {{ ansible_user_dir }}/workspace/test_results.

All logs files (like debug log) should be stored in $LOG_PATH,
and the final test_results (like binaries, artifact) should be
stored in $RESULT_PATH.

Close: https://github.com/theopenlab/openlab/issues/238
