### PR TITLE
Support backends OpenStack Stein

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -61,6 +61,15 @@
     run: playbooks/terraform-provider-openstack-acceptance-test/run.yaml
 
 - job:
+    name: terraform-provider-openstack-acceptance-test-stein
+    parent: terraform-provider-openstack-acceptance-test
+    description: |
+      Run terraform provider openstack acceptance test on stein branch
+    vars:
+      global_env:
+        OS_BRANCH: stable/stein
+
+- job:
     name: terraform-provider-openstack-acceptance-test-rocky
     parent: terraform-provider-openstack-acceptance-test
     description: |
@@ -455,6 +464,20 @@
       os_sdk: openstacksdk
 
 - job:
+    name: openstacksdk-ansible-functional-devstack-stein
+    parent: init-test
+    description: |
+      Run openstacksdk ansible functional tests against a stein devstack using git stable-2.7 branch version of ansible.
+    run: playbooks/ansible-functional-devstack/run.yaml
+    required-projects:
+      - openstack/openstacksdk
+    override-checkout: stable-2.7
+    vars:
+      os_sdk: openstacksdk
+      global_env:
+        OS_BRANCH: stable/stein
+
+- job:
     name: openstacksdk-ansible-functional-devstack-rocky
     parent: init-test
     description: |
@@ -684,6 +707,17 @@
     override-checkout: v1.3.3
 
 - job:
+    name: packer-functional-devstack-stein
+    parent: init-test
+    description: |
+      Test image building functionality of Packer of v1.3.3 against stein devstack.
+    run: playbooks/packer-functional-devstack/run.yaml
+    vars:
+      global_env:
+        OS_BRANCH: stable/stein
+    override-checkout: v1.3.3
+
+- job:
     name: packer-functional-devstack-rocky
     parent: init-test
     description: |
@@ -873,6 +907,18 @@
         OS_BRANCH: stable/rocky
     override-checkout: v0.16.1
 
+- job:
+    name: docker-machine-functional-devstack-stein
+    parent: init-test
+    description: |
+      Test image building functionality of Docker machine of v0.16.1 version against
+      devstack of Stein.
+    run: playbooks/docker-machine-functional-devstack/run.yaml
+    vars:
+      global_env:
+        OS_BRANCH: stable/stein
+    override-checkout: v0.16.1
+
 # bosh huaweicloud cpi jobs
 - job:
     name: bosh-huaweicloud-cpi-release-validator-test-huaweicloud
@@ -978,6 +1024,16 @@
     vars:
       global_env:
         OS_BRANCH: stable/rocky
+
+- job:
+    name: manageiq-providers-openstack-test-devstack-stein
+    parent: init-test
+    description: |
+      This job run tests of manageiq-providers-openstack aganist devstack of Stein.
+    run: playbooks/manageiq-providers-openstack-test-devstack/run.yaml
+    vars:
+      global_env:
+        OS_BRANCH: stable/stein
 
 - job:
     name: manageiq-providers-openstack-test-huaweicloud

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -30,6 +30,8 @@
 #            branches: stable-2.7
         - openstacksdk-ansible-functional-devstack:
             branches: stable-2.7
+        - openstacksdk-ansible-functional-devstack-stein:
+            branches: stable-2.7
         - openstacksdk-ansible-functional-devstack-rocky:
             branches: stable-2.7
         - openstacksdk-ansible-functional-devstack-queens:
@@ -132,6 +134,8 @@
 #            branches: master
         - packer-functional-devstack:
             branches: master
+        - packer-functional-devstack-stein:
+            branches: master
         - packer-functional-devstack-rocky:
             branches: master
         - packer-functional-devstack-queens:
@@ -161,6 +165,8 @@
       jobs:
 #        - docker-machine-functional-huaweicloud:
 #            branches: master
+        - docker-machine-functional-devstack-stein:
+            branches: master
         - docker-machine-functional-devstack-rocky:
             branches: master
         - docker-machine-functional-devstack-queens:
@@ -189,6 +195,8 @@
 #        - manageiq-providers-openstack-test-huaweicloud:
 #            branches: master
         - manageiq-providers-openstack-test-devstack-master:
+            branches: master
+        - manageiq-providers-openstack-test-devstack-stein:
             branches: master
         - manageiq-providers-openstack-test-devstack-rocky:
             branches: master


### PR DESCRIPTION
Support acceptance test against OpenStack Stein release in OpenLab

Add periodic jobs for ansible/packer/docker-machine/manageiq
against OpenStack Stein release.

Related: theopenlab/openlab#231