### PR TITLE
Add pipeline 'recheck stable/stein'

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -174,6 +174,30 @@
         status: 'failure'
       mysql:
 
+- pipeline:
+    name: recheck-stein
+    description: |
+      Commenting "recheck stable/stein" enter this pipeline to run tests on
+      stable/stein of OpenStack and receive an initial +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*recheck\s+stable\/stein\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
 # NOTES: Deprecated, don't accept any new jobs, but please don't remove it,
 #        some outside projects refer name "periodic" in repository.
 - pipeline:


### PR DESCRIPTION
Add a pipeline to trigger acceptance tests against
OpenStack Stein release when comment 'recheck stable/stein'
in pull request.

Related: theopenlab/openlab#231