### PR TITLE
Use ruby 2.4.0 instead for manageiq jobs

### DIFF
--- a/playbooks/manageiq-providers-openstack-test-devstack/run.yaml
+++ b/playbooks/manageiq-providers-openstack-test-devstack/run.yaml
@@ -4,7 +4,8 @@
     #NOTES: manageiq-providers-openstack don't support OpenStack version discovery, so enable legacy endpoint format.
     DISABLE_HTTPD_MOD_WSGI: true
   roles:
-    - config-ruby
+    - role: config-ruby
+      ruby_version: '2.4.0'
     - clone-devstack-gate-to-workspace
     - role: create-devstack-local-conf
       enable_services:


### PR DESCRIPTION
An error occurred while installing dry-validation (0.13.1),
and Bundler cannot continue for manageiq jobs.
Change to use ruby 2.4.0 to fix this bug.

Related-Bug: theopenlab/openlab#246