### PR TITLE
Use two separated jobs for kubeflow/volcano jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1238,10 +1238,10 @@
       is_gpu_enabled: true
 
 - job:
-    name: tensorflow-benchmarks-volcano-kubeflow-k8s-v1.14.0
+    name: tensorflow-benchmarks-kubeflow-k8s-v1.14.0
     parent: init-test
     description: |
-      Test benchmarks of tensorflow + volcano/kubeflow on k8s cluster
+      Test benchmarks of tensorflow + kubeflow on k8s cluster
     run: playbooks/tensorflow-volcano-kubeflow-integration-test-k8s/run.yaml
     post-run: playbooks/tensorflow-volcano-kubeflow-integration-test-k8s/post.yaml
     timeout: 86000 # almost 1 day(86400)
@@ -1249,6 +1249,37 @@
       k8s_log_dir: '{{ ansible_user_dir }}/workspace/logs/kubernetes'
       kubernetes_version: 1.14.0
       run_kubeflow_tfbenchmarks: true
+    nodeset:
+      nodes:
+        - name: k8s-master
+          label: ubuntu-xenial-tf
+        - name: k8s-node-1
+          label: ubuntu-xenial-tf
+        - name: k8s-node-2
+          label: ubuntu-xenial-tf
+        - name: k8s-node-3
+          label: ubuntu-xenial-tf
+        - name: k8s-node-4
+          label: ubuntu-xenial-tf
+      groups:
+        - name: k8s-nodes
+          nodes:
+            - k8s-node-1
+            - k8s-node-2
+            - k8s-node-3
+            - k8s-node-4
+
+- job:
+    name: tensorflow-benchmarks-volcano-k8s-v1.14.0
+    parent: init-test
+    description: |
+      Test benchmarks of tensorflow + volcano on k8s cluster
+    run: playbooks/tensorflow-volcano-kubeflow-integration-test-k8s/run.yaml
+    post-run: playbooks/tensorflow-volcano-kubeflow-integration-test-k8s/post.yaml
+    timeout: 86000 # almost 1 day(86400)
+    vars:
+      k8s_log_dir: '{{ ansible_user_dir }}/workspace/logs/kubernetes'
+      kubernetes_version: 1.14.0
       run_volcano_tfbenchmarks: true
     nodeset:
       nodes:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -25,7 +25,8 @@
     name: theopenlab/volcano
     check:
       jobs:
-        - tensorflow-benchmarks-volcano-kubeflow-k8s-v1.14.0
+        - tensorflow-benchmarks-kubeflow-k8s-v1.14.0
+        - tensorflow-benchmarks-volcano-k8s-v1.14.0
 
 ####################### periodic jobs on 00:00/12:00 ##########################
 - project:


### PR DESCRIPTION
For convenient to comparing results, use two separated CI jobs for
running Tensorflow CNN benchmarks on kubeflow/volcano.