### PR TITLE
Reduce the number of batches to be run in TFjobs

### DIFF
--- a/playbooks/tensorflow-volcano-kubeflow-integration-test-k8s/kf-tfbenchmarks.yaml.j2
+++ b/playbooks/tensorflow-volcano-kubeflow-integration-test-k8s/kf-tfbenchmarks.yaml.j2
@@ -14,6 +14,8 @@ spec:
             - python
             - tf_cnn_benchmarks.py
             - --batch_size=32
+            - --num_batches=15
+            - --num_warmup_batches=10
             - --model=resnet50
             - --variable_update=parameter_server
             - --flush_stdout=true
@@ -42,6 +44,8 @@ spec:
             - python
             - tf_cnn_benchmarks.py
             - --batch_size=32
+            - --num_batches=15
+            - --num_warmup_batches=10
             - --model=resnet50
             - --variable_update=parameter_server
             - --flush_stdout=true

--- a/playbooks/tensorflow-volcano-kubeflow-integration-test-k8s/kubeflow_tfbenchmarks.yaml
+++ b/playbooks/tensorflow-volcano-kubeflow-integration-test-k8s/kubeflow_tfbenchmarks.yaml
@@ -110,11 +110,7 @@
 
     - name: create kf-tfbenchmarks directory
       file: path="{{ ansible_user_dir }}/workspace/kf-tfbenchmarks/{{ item }}" state=directory
-      with_items:
-        - case1
-        - case2
-        - case3
-        - case4
+      with_items: "{{ cases | json_query('[*].case')|unique }}"
 
     - name: customize kubeflow tfbenchmarks templates
       become: yes

--- a/playbooks/tensorflow-volcano-kubeflow-integration-test-k8s/vc-tfbenchmarks.yaml.j2
+++ b/playbooks/tensorflow-volcano-kubeflow-integration-test-k8s/vc-tfbenchmarks.yaml.j2
@@ -56,7 +56,7 @@ spec:
                 - |
                   PS_HOST=`cat /etc/volcano/ps.host | sed 's/$/&:2222/g' | tr "\n" ","`;
                   WORKER_HOST=`cat /etc/volcano/worker.host | sed 's/$/&:2222/g' | tr "\n" ","`;
-                  python tf_cnn_benchmarks.py --batch_size=32 --model=resnet50 --variable_update=parameter_server --flush_stdout=true --num_gpus=1 --local_parameter_device=cpu --device=cpu --data_format=NHWC --job_name=ps --task_index=${VK_TASK_INDEX} --ps_hosts=${PS_HOST} --worker_hosts=${WORKER_HOST}
+                  python tf_cnn_benchmarks.py --batch_size=32 --num_batches=15 --num_warmup_batches=10 --model=resnet50 --variable_update=parameter_server --flush_stdout=true --num_gpus=1 --local_parameter_device=cpu --device=cpu --data_format=NHWC --job_name=ps --task_index=${VK_TASK_INDEX} --ps_hosts=${PS_HOST} --worker_hosts=${WORKER_HOST}
               image: volcanosh/example-tf:0.0.3
               name: tensorflow
               ports:
@@ -87,7 +87,7 @@ spec:
                 - |
                   PS_HOST=`cat /etc/volcano/ps.host | sed 's/$/&:2222/g' | tr "\n" ","`;
                   WORKER_HOST=`cat /etc/volcano/worker.host | sed 's/$/&:2222/g' | tr "\n" ","`;
-                  python tf_cnn_benchmarks.py --batch_size=32 --model=resnet50 --variable_update=parameter_server --flush_stdout=true --num_gpus=1 --local_parameter_device=cpu --device=cpu --data_format=NHWC --job_name=worker --task_index=${VK_TASK_INDEX} --ps_hosts=${PS_HOST} --worker_hosts=${WORKER_HOST}
+                  python tf_cnn_benchmarks.py --batch_size=32 --num_batches=15 --num_warmup_batches=10 --model=resnet50 --variable_update=parameter_server --flush_stdout=true --num_gpus=1 --local_parameter_device=cpu --device=cpu --data_format=NHWC --job_name=worker --task_index=${VK_TASK_INDEX} --ps_hosts=${PS_HOST} --worker_hosts=${WORKER_HOST}
               image: volcanosh/example-tf:0.0.3
               name: tensorflow
               ports:

--- a/playbooks/tensorflow-volcano-kubeflow-integration-test-k8s/volcano_tfbenchmarks.yaml
+++ b/playbooks/tensorflow-volcano-kubeflow-integration-test-k8s/volcano_tfbenchmarks.yaml
@@ -54,11 +54,7 @@
 
     - name: create vc-tfbenchmarks directory
       file: path="{{ ansible_user_dir }}/workspace/vc-tfbenchmarks/{{ item }}" state=directory
-      with_items:
-        - case1
-        - case2
-        - case3
-        - case4
+      with_items: "{{ cases | json_query('[*].case')|unique }}"
 
     - name: customize volcano tfbenchmarks templates
       become: yes


### PR DESCRIPTION
As we use VMs with CPUs resources to run the tensorflow benchmarks, it
will be very slow, we only care about the scheduling performances
between kubeflow and volcano, so we can reduce the bacthes of training
examples in the Tensorflow benchmarks to save time.