### PR TITLE
Use 2 TF jobs for CI jobs testing of Volcano demo

### DIFF
--- a/playbooks/tensorflow-volcano-kubeflow-integration-test-k8s/kubeflow_tfbenchmarks.yaml
+++ b/playbooks/tensorflow-volcano-kubeflow-integration-test-k8s/kubeflow_tfbenchmarks.yaml
@@ -12,12 +12,6 @@
           ps_cpu: 1000m, ps_mem: 1000Mi, worker_cpu: 2000m, worker_mem: 3800Mi }
       - { case: "case4", name: "kf-tfbenchmarks-2", ps_replicas: 2, worker_replicas: 4,
           ps_cpu: 1000m, ps_mem: 1000Mi, worker_cpu: 2000m, worker_mem: 3800Mi }
-      - { case: "case4", name: "kf-tfbenchmarks-3", ps_replicas: 2, worker_replicas: 4,
-          ps_cpu: 1000m, ps_mem: 1000Mi, worker_cpu: 2000m, worker_mem: 3800Mi }
-      - { case: "case4", name: "kf-tfbenchmarks-4", ps_replicas: 2, worker_replicas: 4,
-          ps_cpu: 1000m, ps_mem: 1000Mi, worker_cpu: 2000m, worker_mem: 3800Mi }
-      - { case: "case4", name: "kf-tfbenchmarks-5", ps_replicas: 2, worker_replicas: 4,
-          ps_cpu: 1000m, ps_mem: 1000Mi, worker_cpu: 2000m, worker_mem: 3800Mi }
     # We only test the typical case case4 without case1,2,3, otherwise, it will take very long time.
     cases_to_run:
       - case4

--- a/playbooks/tensorflow-volcano-kubeflow-integration-test-k8s/volcano_tfbenchmarks.yaml
+++ b/playbooks/tensorflow-volcano-kubeflow-integration-test-k8s/volcano_tfbenchmarks.yaml
@@ -12,13 +12,7 @@
           ps_cpu: 1000m, ps_mem: 1000Mi, worker_cpu: 2000m, worker_mem: 3800Mi, minavailable: 6}
       - { case: "case4", name: "vc-tfbenchmarks-2", ps_replicas: 2, worker_replicas: 4,
           ps_cpu: 1000m, ps_mem: 1000Mi, worker_cpu: 2000m, worker_mem: 3800Mi, minavailable: 6}
-      - { case: "case4", name: "vc-tfbenchmarks-3", ps_replicas: 2, worker_replicas: 4,
-          ps_cpu: 1000m, ps_mem: 1000Mi, worker_cpu: 2000m, worker_mem: 3800Mi, minavailable: 6}
-      - { case: "case4", name: "vc-tfbenchmarks-4", ps_replicas: 2, worker_replicas: 4,
-          ps_cpu: 1000m, ps_mem: 1000Mi, worker_cpu: 2000m, worker_mem: 3800Mi, minavailable: 6}
-      - { case: "case4", name: "vc-tfbenchmarks-5", ps_replicas: 2, worker_replicas: 4,
-          ps_cpu: 1000m, ps_mem: 1000Mi, worker_cpu: 2000m, worker_mem: 3800Mi, minavailable: 6}
-    # We only test the typical case case4 without case1,2,3, otherwise, it will take very long time.
+      # We only test the typical case case4 without case1,2,3, otherwise, it will take very long time.
     cases_to_run:
       - case4
   tasks:


### PR DESCRIPTION
After talking with mada, 2 TF jobs running in parallel can also present
the performance comparing, and will avoid the CI job timeout of kubeflow
job.