### PR TITLE
Enable bosh cpi test against openstack stein periodic job

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -116,6 +116,8 @@
       jobs:
         - bosh-openstack-cpi-release-acceptance-test:
             branches: master
+        - bosh-openstack-cpi-release-acceptance-test-stein:
+            branches: master
         - bosh-openstack-cpi-release-acceptance-test-rocky:
             branches: master
         - bosh-openstack-cpi-release-acceptance-test-queens:


### PR DESCRIPTION
Run bosh cpi test against openstack stable/stein
in periodic pipeline.

Closes: theopenlab/openlab#265