### PR TITLE
Disable terraform-provider-huaweicloud-acceptance-test-fusioncloud

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -70,12 +70,12 @@
 #        - terraform-provider-openstack-acceptance-test-huaweicloud:
 #            branches: master
 
-- project:
-    name: terraform-providers/terraform-provider-huaweicloud
-    periodic-2/14:
-      jobs:
-        - terraform-provider-huaweicloud-acceptance-test-fusioncloud:
-            branches: master
+#- project:
+#    name: terraform-providers/terraform-provider-huaweicloud
+#    periodic-2/14:
+#      jobs:
+#        - terraform-provider-huaweicloud-acceptance-test-fusioncloud:
+#            branches: master
 
 - project:
     name: helm/charts


### PR DESCRIPTION
The OpenLab is a platform for Opensource SDKs/Tools,
disable the job for testing private cloud.

Closes: theopenlab/openlab#266