### PR TITLE
Update ssh_known_hosts

### DIFF
--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -10,7 +10,7 @@
       fqdn: logs.openlabtesting.org
       path: /srv/static/logs
       ssh_known_hosts: |
-          |1|NtvEbqGyTRXNkorhNM1Et3YF+oQ=|N3pNeAxm+IaJCji6JA3EnuXq3ec= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBzT8yNpSCiwJRxcxo0JisrWMG6cDYF0koGsdgZRULnHfHQ3JRq8hlqWcvx22fqpWxgjUofxXfsIIZFsl/6JpIM=
+          |1|jsNh6O/y2yCUWQbtIH6yydPIgBU=|215KKNVsbaNmfi9bgyrJp89n6eo= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEjcriEaCucbxVUvfzKidWDpPTAlXBdJyyXOsyFgiJD1EDoeiK5aeuBiV5abhKjIa+1TToOgNsJNQmLXWoMrnPg=
       ssh_username: zuul
       ssh_private_key: !encrypted/pkcs1-oaep
         - ByqNA9ahhrhup5ZPEV1AFakIZOA98/r1VytpA4IRWrsW2SKi26Cg4jW9/8acN1rqQqEvR


### PR DESCRIPTION
We change the zuul node to a new ssh_known_hosts, we should also update the know host to make upload logs work.

Related-Bug: theopenlab/openlab#218