### PR TITLE
Extract install openjdk8 to a role

### DIFF
--- a/playbooks/spark-integration-test-kubeadm-k8s/run.yaml
+++ b/playbooks/spark-integration-test-kubeadm-k8s/run.yaml
@@ -1,6 +1,7 @@
 - hosts: all
   become: yes
   roles:
+    - install-openjdk
     - create-single-k8s-cluster-with-kubeadm
   tasks:
     - name: Login dockerhub
@@ -11,8 +12,6 @@
       shell: |
         set -ex
         export KUBECONFIG=/etc/kubernetes/admin.conf
-        # install java8
-        apt-get install openjdk-8-jdk -y
         export JAVA_HOME=$(dirname $(dirname $(update-alternatives --list javac)))
 
         sed -i -e '/127.0.0.1/ s/\(localhost\)/'$(hostname)' \1/' /etc/hosts

--- a/roles/install-openjdk/defaults/main.yaml
+++ b/roles/install-openjdk/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+java_version: '8'

--- a/roles/install-openjdk/tasks/main.yaml
+++ b/roles/install-openjdk/tasks/main.yaml
@@ -1,0 +1,6 @@
+- name: Install java {{ java_version }}
+  shell:
+    cmd: |
+      apt-get install openjdk-{{ java_version }}-jdk -y
+    executable: /bin/bash
+  environment: '{{ global_env }}'


### PR DESCRIPTION
There is some unknown error that causes
spark job exit when installing openjdk8,
extract it to be a role and run it at
the begaining of the job to debug the
root causes.