### PR TITLE
Fix packer-master-functional-devstack for changing "make bin" to "make dev"

### DIFF
--- a/roles/config-packer/tasks/main.yaml
+++ b/roles/config-packer/tasks/main.yaml
@@ -6,13 +6,7 @@
 - name: Install master of Packer from source
   shell: |
     set -ex
-    make bin
-    # Currently, we use ubuntu amd64 image to test, but the make bin failed to
-    # find the right version, so in the end of above will fail to copy the
-    # binary into /usr/local/bin/
-    if [ -d "./pkg/linux_amd64/" ]; then
-        cp ./pkg/linux_amd64/packer /usr/local/bin/
-    fi
+    make dev
     packer version
   environment: '{{ global_env }}'
   args:

--- a/roles/config-packer/tasks/main.yaml
+++ b/roles/config-packer/tasks/main.yaml
@@ -7,6 +7,12 @@
   shell: |
     set -ex
     make bin
+    # Currently, we use ubuntu amd64 image to test, but the make bin failed to
+    # find the right version, so in the end of above will fail to copy the
+    # binary into /usr/local/bin/
+    if [ -d "./pkg/linux_amd64/" ]; then
+        cp ./pkg/linux_amd64/packer /usr/local/bin/
+    fi
     packer version
   environment: '{{ global_env }}'
   args:


### PR DESCRIPTION
This fix the wrong platform and ARCH name from 'uname -a', as we use the ubuntu and X86 image, so we force to make packer job use linux_amd64 packer, and copy it into the right place.

Close: theopenlab/openlab#247