### PR TITLE
Use flannel network add on when create k8s cluster

### DIFF
--- a/roles/create-single-k8s-cluster-with-kubeadm/tasks/main.yml
+++ b/roles/create-single-k8s-cluster-with-kubeadm/tasks/main.yml
@@ -34,14 +34,14 @@
       cat /etc/resolv.conf
 
       ## Initializing master
-      kubeadm init --pod-network-cidr=192.168.0.0/16 --kubernetes-version="{{ kubernetes_version }}"
+      sysctl net.bridge.bridge-nf-call-iptables=1
+      kubeadm init --pod-network-cidr=10.244.0.0/16 --kubernetes-version="{{ kubernetes_version }}"
 
       mkdir -p $HOME/.kube
       sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
 
       ## Installing a pod network add-on.
-      kubectl apply -f https://docs.projectcalico.org/v3.3/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
-      kubectl apply -f https://docs.projectcalico.org/v3.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
+      kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/62e44c867a2846fefb68bd5f178daf4da3095ccb/Documentation/kube-flannel.yml
 
       # make sure we can schedule pods on the master.
       kubectl taint nodes --all node-role.kubernetes.io/master-


### PR DESCRIPTION
The default pod network cidr is 192.168.0.0/16, it
perhaps conflict with the node ip, there are two ways
to fix this, change the cidr or change the network add on,
we choose the second one here.

Related-Bug: theopenlab/openlab#298