### PR TITLE
Add no_log when setting gcp account

### DIFF
--- a/roles/export-kind-gcp-account/tasks/main.yaml
+++ b/roles/export-kind-gcp-account/tasks/main.yaml
@@ -1,9 +1,11 @@
 - name: Set google account key file path
   set_fact:
     gcp_key_file: '/tmp/gcp_key.json'
+  no_log: yes
 
 - name: Save google account key file
   shell:
     cmd: |
       echo '{{ gcp_account_kind.key_json }}' > '{{ hostvars[inventory_hostname]["gcp_key_file"] }}'
     executable: /bin/bash
+  no_log: yes


### PR DESCRIPTION
Add no_log when setting gcp account to avoid password leak since the prblem in
post job has been solved.

Related-Bug: theopenlab/openlab#257