### PR TITLE
Upload magnum-auto-healer image to k8scloudprovider dockerhub

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -152,6 +152,7 @@
             docker push ${REGISTRY}/k8s-keystone-auth:${VERSION} | tee $LOG_DIR/image-build-upload.log
             docker push ${REGISTRY}/octavia-ingress-controller:${VERSION} | tee $LOG_DIR/image-build-upload.log
             docker push ${REGISTRY}/manila-provisioner:${VERSION} | tee $LOG_DIR/image-build-upload.log
+            docker push ${REGISTRY}/magnum-auto-healer:${VERSION} | tee $LOG_DIR/image-build-upload.log
           else
             exit 0;
           fi


### PR DESCRIPTION
magnum-auto-healer binary was added to cloud-provider-openstack recently, we need to build and upload its image to dockerhub as well.