### PR TITLE
Disable q-lbaas for mitaka devstack enabled octavia

### DIFF
--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -190,9 +190,13 @@
     cmd: |
       set -e
       set -x
-      # enable q-lbaasv2 for stable/mitaka branch
+      # enable q-lbaasv2 and disable q-lbaas for stable/mitaka branch
       if [[ "{{ global_env.OS_BRANCH }}" == "stable/mitaka" ]];then
           services='octavia,o-cw,o-hm,o-hk,o-api,q-lbaasv2'
+          cat << EOF >> /tmp/dg-local.conf
+          disable_service q-lbaas
+          enable_plugin neutron-lbaas https://opendev.org/openstack/neutron-lbaas
+          EOF
       else
           services='octavia,o-cw,o-hm,o-hk,o-api'
       fi


### PR DESCRIPTION
When install mitaka devstack, the service q-lbaas is
enabled default, but if octavia enabled, it requires
the service q-lbaasv2. So let's disable q-lbaas and
enable q-lbaasv2 to make sure Neutron can be started.

Closes: theopenlab/openlab#304