### PR TITLE
Use "go install" instead of "make" command for compiling packer

### DIFF
--- a/roles/config-packer/tasks/main.yaml
+++ b/roles/config-packer/tasks/main.yaml
@@ -6,7 +6,7 @@
 - name: Install master of Packer from source
   shell: |
     set -ex
-    make dev
+    go install
     packer version
   environment: '{{ global_env }}'
   args:


### PR DESCRIPTION
The "make bin" command has been broken(fixed but not released)
The "make dev" command can only work on master branch

Closes: #theopenlab/openlab#306