### PR TITLE
Use go install packer instead make

### DIFF
--- a/roles/config-packer/tasks/main.yaml
+++ b/roles/config-packer/tasks/main.yaml
@@ -6,7 +6,7 @@
 - name: Install master of Packer from source
   shell: |
     set -ex
-    make dev
+    go install
     packer version
   environment: '{{ global_env }}'
   args:


### PR DESCRIPTION
The packer can be installed by go install, if we want to use make in the
future to follow the official packer doc, we can change back when the
new release raise.