### PR TITLE
Add new role "install-docker"

### DIFF
--- a/roles/config-docker-machine/tasks/main.yaml
+++ b/roles/config-docker-machine/tasks/main.yaml
@@ -3,15 +3,16 @@
   include_role:
     name: config-golang
 
+- name: Install Runtime Docker CE
+  include_role:
+    name: install-docker
+  vars:
+    docker_version: '18.06'
+
 - name: Compiled and install docker-machine from source
   shell:
     cmd: |
       set -ex
-
-      # Install docker
-      apt-get update
-      apt-get install apt-transport-https ca-certificates -y
-      wget -qO- https://get.docker.com/ | sh
 
       # Build docker-machine
       make build

--- a/roles/install-docker-ce/tasks/main.yml
+++ b/roles/install-docker-ce/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Install Runtime Docker CE using the repository
+- name: (Deprecated, instead by "install-docker") Install Runtime Docker CE using the repository
   shell:
     cmd: |
       set -x

--- a/roles/install-docker/defaults/main.yaml
+++ b/roles/install-docker/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+docker_version: "latest"

--- a/roles/install-docker/tasks/main.yml
+++ b/roles/install-docker/tasks/main.yml
@@ -1,0 +1,34 @@
+- name: Install Docker CE {{ docker_version }} using get.docker.com
+  shell:
+    cmd: |
+      set -x
+      set -e
+
+      # Download docker install script
+      # The script worked on multiple OS (Ubuntu, CentOS, SUSE) and Archs (x86_64 and aarch64)
+      # and have consistent docker-ce version, like: 18.06, 18.09
+      curl -fsSL https://get.docker.com -o get-docker.sh
+
+      # Install docker ce.
+      if [[ "{{ docker_version }}" == "latest" ]]; then
+          sh get-docker.sh
+      else
+          VERSION="{{ docker_version }}" sh get-docker.sh
+      fi
+
+      # Stopping firewall and allow all traffic
+      iptables -F
+      iptables -X
+      iptables -t nat -F
+      iptables -t nat -X
+      iptables -t mangle -F
+      iptables -t mangle -X
+      iptables -P INPUT ACCEPT
+      iptables -P FORWARD ACCEPT
+      iptables -P OUTPUT ACCEPT
+
+      # Restart docker.
+      systemctl daemon-reload
+      systemctl restart docker
+
+    executable: /bin/bash

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1326,7 +1326,7 @@
       - Category:Cloud
       - Project:docker/machine
       - Application:Docker Machine@v0.16.1
-      - Application:Docker@latest-release
+      - Application:Docker@18.06
       - Application:Go@1.12.1
       - Application:OpenStack@mitaka
       - OS:ubuntu-trusty
@@ -1354,7 +1354,7 @@
       - Project:docker/machine
       - Application:Docker Machine@v0.16.1
       - Application:OpenStack@newton
-      - Application:Docker@latest-release
+      - Application:Docker@18.06
       - Application:Go@1.12.1
       - OS:ubuntu-xenial
       - Arch:x86_64
@@ -1381,7 +1381,7 @@
       - Project:docker/machine
       - Application:Docker Machine@v0.16.1
       - Application:OpenStack@ocata
-      - Application:Docker@latest-release
+      - Application:Docker@18.06
       - Application:Go@1.12.1
       - OS:ubuntu-xenial
       - Arch:x86_64
@@ -1408,7 +1408,7 @@
       - Project:docker/machine
       - Application:Docker Machine@v0.16.1
       - Application:OpenStack@pike
-      - Application:Docker@latest-release
+      - Application:Docker@18.06
       - Application:Go@1.12.1
       - OS:ubuntu-xenial
       - Arch:x86_64
@@ -1435,7 +1435,7 @@
       - Project:docker/machine
       - Application:Docker Machine@v0.16.1
       - Application:OpenStack@queens
-      - Application:Docker@latest-release
+      - Application:Docker@18.06
       - Application:Go@1.12.1
       - OS:ubuntu-xenial
       - Arch:x86_64
@@ -1462,7 +1462,7 @@
       - Project:docker/machine
       - Application:Docker Machine@v0.16.1
       - Application:OpenStack@rocky
-      - Application:Docker@latest-release
+      - Application:Docker@18.06
       - Application:Go@1.12.1
       - OS:ubuntu-xenial
       - Arch:x86_64
@@ -1489,7 +1489,7 @@
       - Project:docker/machine
       - Application:Docker Machine@v0.16.1
       - Application:OpenStack@stein
-      - Application:Docker@latest-release
+      - Application:Docker@18.06
       - Application:Go@1.12.1
       - OS:ubuntu-xenial
       - Arch:x86_64


### PR DESCRIPTION
The new role "install-docker" install docker-ce by using get.docker.com
script, it support multiple OS and arch, and keep consistent docker-ce
version, mark role "install-docker-ce" as deprecated, and apply new role
in all of docker-machine jobs. Update tag of docker-machine job from
latest-release to 18.06 in order to avoid confusions.

Related-Bug: theopenlab/openlab#308