### PR TITLE
Fix install-docker role

### DIFF
--- a/playbooks/docker-machine-functional-devstack/run.yaml
+++ b/playbooks/docker-machine-functional-devstack/run.yaml
@@ -1,10 +1,10 @@
 - hosts: all
   become: yes
   roles:
+    - config-docker-machine
     - clone-devstack-gate-to-workspace
     - create-devstack-local-conf
     - install-devstack
-    - config-docker-machine
   tasks:
     - name: Run Integration tests of Docker machine against devstack
       shell:

--- a/playbooks/spark-integration-test-minikube-k8s/run.yaml
+++ b/playbooks/spark-integration-test-minikube-k8s/run.yaml
@@ -17,7 +17,7 @@
         kubectl create clusterrolebinding spark-role --clusterrole=edit --serviceaccount=default:spark --namespace=default
 
         # NOTE: the distribution step may fail due to dependencies downloading failure, so we suport retry
-        for i in $(seq 1 3); do ./dev/make-distribution.sh --tgz -Pkubernetes --r && s=0 && break || s=$? && sleep 5; done; (exit $s)
+        for i in $(seq 1 3); do ./dev/make-distribution.sh --r --tgz -Pkubernetes && s=0 && break || s=$? && sleep 5; done; (exit $s)
 
         pushd resource-managers/kubernetes/integration-tests
         dev/dev-run-integration-tests.sh --spark-tgz $(realpath ../../../spark-*.tgz) --namespace default --service-account spark

--- a/roles/config-docker-machine/tasks/main.yaml
+++ b/roles/config-docker-machine/tasks/main.yaml
@@ -3,12 +3,6 @@
   include_role:
     name: config-golang
 
-- name: Install Runtime Docker CE
-  include_role:
-    name: install-docker
-  vars:
-    docker_version: '18.06'
-
 - name: Compiled and install docker-machine from source
   shell:
     cmd: |

--- a/roles/config-docker-machine/tasks/main.yaml
+++ b/roles/config-docker-machine/tasks/main.yaml
@@ -3,6 +3,12 @@
   include_role:
     name: config-golang
 
+- name: Install Runtime Docker CE
+  include_role:
+    name: install-docker
+  vars:
+    docker_version: '18.06'
+
 - name: Compiled and install docker-machine from source
   shell:
     cmd: |

--- a/roles/install-docker/tasks/main.yml
+++ b/roles/install-docker/tasks/main.yml
@@ -15,4 +15,20 @@
       else
           VERSION="{{ docker_version }}" sh get-docker.sh
       fi
+
+      # Stopping firewall and allow all traffic
+      iptables -F
+      iptables -X
+      iptables -t nat -F
+      iptables -t nat -X
+      iptables -t mangle -F
+      iptables -t mangle -X
+      iptables -P INPUT ACCEPT
+      iptables -P FORWARD ACCEPT
+      iptables -P OUTPUT ACCEPT
+
+      # NOTE: systemctl is not available in Ubuntu 14.04, so use "service"
+      # command for compatibility
+      service docker restart
+
     executable: /bin/bash

--- a/roles/install-docker/tasks/main.yml
+++ b/roles/install-docker/tasks/main.yml
@@ -27,8 +27,8 @@
       iptables -P FORWARD ACCEPT
       iptables -P OUTPUT ACCEPT
 
-      # Restart docker.
-      systemctl daemon-reload
-      systemctl restart docker
+      # NOTE: systemctl is not available in Ubuntu 14.04, so use "service"
+      # command for compatibility
+      service docker restart
 
     executable: /bin/bash

--- a/roles/install-docker/tasks/main.yml
+++ b/roles/install-docker/tasks/main.yml
@@ -15,20 +15,4 @@
       else
           VERSION="{{ docker_version }}" sh get-docker.sh
       fi
-
-      # Stopping firewall and allow all traffic
-      iptables -F
-      iptables -X
-      iptables -t nat -F
-      iptables -t nat -X
-      iptables -t mangle -F
-      iptables -t mangle -X
-      iptables -P INPUT ACCEPT
-      iptables -P FORWARD ACCEPT
-      iptables -P OUTPUT ACCEPT
-
-      # NOTE: systemctl is not available in Ubuntu 14.04, so use "service"
-      # command for compatibility
-      service docker restart
-
     executable: /bin/bash


### PR DESCRIPTION
1. systemctl is not available on Ubuntu 14.04, so using
   "service docker restart" as a workaround.
2. change option "--r" position in spark-inegration-test-minikube-k8s
   job to avoid "--r" is bypassed to mvn.
3. change the importing order of roles in docker-machine job to make sure the
  docker installation won't clean the iptables rules added by devstack

Related-Bug: theopenlab/openlab#308
Related-Bug: theopenlab/openlab#310

Co-authored-by: liu-sheng <liusheng2048@gmail.com>