### PR TITLE
Fix cloud-provider-openstack CI error

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -116,6 +116,11 @@
           # Run e2e test using local deployment/provider
           # Must run kubetest under kubernetes root directory
           cd '{{ k8s_src_dir }}'
+
+          # Clean up the pre-built result folder in `install-k8s` role.
+          # Otherwise, kubetest will fail due to some unknow conflicts.
+          rm -rf _output/
+
           kubetest --dump=$LOG_DIR \
               --test \
               --build=quick \


### PR DESCRIPTION
Clean up the pre-built k8s binaries output folder which is generated in`install-k8s` role. Otherwise `kubetest` will fail due to some unknown conflicts.

Related-Bug: theopenlab/openlab#317