### PR TITLE
Add job to build/test spark on arm64

### DIFF
--- a/playbooks/spark-unit-test-arm64/run.yaml
+++ b/playbooks/spark-unit-test-arm64/run.yaml
@@ -1,0 +1,39 @@
+- hosts: all
+  become: yes
+  roles:
+    - install-openjdk
+    - install-maven
+
+- hosts: all
+  tasks:
+    - name: 'Step1: Try to build Spark directly'
+      shell: |
+        set -xo pipefail
+        # build and test spark
+        ./build/mvn -DskipTests clean package 2>&1 | tee "{{ ansible_user_dir }}/workspace/logs/spark_build_original.log"
+        # mvn test will failed due to the leveldbjni has no aarch64 supporting
+        ./build/mvn test 2>&1 | tee "{{ ansible_user_dir }}/workspace/logs/spark_test_original.log"
+      args:
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
+      ignore_errors: yes
+      environment: '{{ global_env }}'
+
+    - name: 'Step2: Build and run unit tests for apache spark after fixing errors'
+      shell:
+        cmd: |
+          set -exo pipefail
+
+          # fix kafka authfail tests
+          sudo sed -i -e 's/^127.0.0.1 .*$/127.0.0.1 localhost '$(hostname)'/g' /etc/hosts
+
+          # install org.openlabtesting.leveldbjni which supports aarch64
+          wget https://repo1.maven.org/maven2/org/openlabtesting/leveldbjni/leveldbjni-all/1.8/leveldbjni-all-1.8.jar
+          mvn install:install-file -DgroupId=org.fusesource.leveldbjni -DartifactId=leveldbjni-all -Dversion=1.8 -Dpackaging=jar -Dfile=leveldbjni-all-1.8.jar
+
+          ./build/mvn clean install -DskipTests -Phadoop-{{ hadoop_version }} -Pyarn -Phive -Phive-thriftserver -Pkinesis-asl -Pmesos 2>&1 | tee "{{ ansible_user_dir }}/workspace/logs/spark_build.log"
+          ./build/mvn test -Phadoop-{{ hadoop_version }} -Pyarn -Phive -Phive-thriftserver -Pkinesis-asl -Pmesos 2>&1 | tee "{{ ansible_user_dir }}/workspace/logs/spark_test.log"
+
+        chdir: '{{ zuul.project.src_dir }}'
+        executable: /bin/bash
+      environment: '{{ global_env }}'

--- a/roles/install-maven/defaults/main.yaml
+++ b/roles/install-maven/defaults/main.yaml
@@ -1,2 +1,2 @@
 ---
-maven_version: '3.6.1'
+maven_version: '3.6.2'

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -2215,3 +2215,23 @@
       - OS:ubuntu-xenial
       - Arch:arm64
       - BuildType:Compile
+
+# Spark arm64 build and run unit tests periodic job
+- job:
+    name: spark-master-unit-test-hadoop-2.7-arm64
+    parent: init-test
+    description: |
+      Apache Spark build and run unit tests on arm64 server
+    run: playbooks/spark-unit-test-arm64/run.yaml
+    vars:
+      hadoop_version: 2.7
+    nodeset: ubuntu-xenial-arm64
+    tags:
+      - Category:BigData
+      - Project:apache/spark
+      - Application:Spark@master
+      - Application:Hadoop@2.7
+      - OS:ubuntu-xenial
+      - Arch:arm64
+      - BuildType:Unit test
+    timeout: 54000

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -44,6 +44,8 @@
             branches: master
         - spark-integration-test-minikube-k8s-v1.13.3:
             branches: master
+        - spark-master-unit-test-hadoop-2.7-arm64:
+            branches: master
 
 ####################### periodic jobs on 02:00/14:00 ##########################
 - project:


### PR DESCRIPTION
Add periodic job to build and test spark on
aarch64 instance.

Related-Bug: theopenlab/openlab#316
Related-Bug: theopenlab/openlab#318