### PR TITLE
Do not use `no_log` and `register` together

### DIFF
--- a/roles/install-openjdk/tasks/main.yaml
+++ b/roles/install-openjdk/tasks/main.yaml
@@ -8,7 +8,6 @@
 
 - name: Get host jvm path
   shell: echo $(dirname $(dirname $(update-alternatives --list javac)))
-  no_log: yes
   register: real_java_home
 
 - name: Set java env vars


### PR DESCRIPTION
If using `no_log` and `register` together, the `regitster` one will be empty.