### PR TITLE
Enable barbican plugin individually

### DIFF
--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -208,6 +208,18 @@
     - global_env.OS_BRANCH != 'stable/queens'
     - '"octavia" in enable_services'
 
+- name: create devstack local conf with barbican enabled
+  shell:
+    cmd: |
+      set -e
+      set -x
+      cat << EOF >> /tmp/dg-local.conf
+      enable_plugin barbican https://opendev.org/openstack/barbican
+      EOF
+    executable: /bin/bash
+  when:
+    - '"barbican" in enable_services'
+
 - name: create devstack local conf with fwaas v1 enabled
   shell:
     cmd: |


### PR DESCRIPTION
Now we enable barbican only if 'octavia' or 'lbaas'
enabled, to make sure users can enable barbican
individually.

Close: theopenlab/openlab#320