### PR TITLE
Add temp cpo jobs for test

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -2189,3 +2189,172 @@
       - OS:ubuntu-xenial
       - Arch:arm64
       - BuildType:Compile
+
+# Temp Kubernetes cloud-provider-openstack jobs on citynetwork cloud, these
+# jobs will be removed later.
+- job:
+    name: cloud-provider-openstack-test-citynetwork
+    parent: golang-test
+    description: |
+      Base job for all types of cloud-provider-openstack test jobs
+    pre-run: playbooks/cloud-provider-openstack-test/pre.yaml
+    post-run: playbooks/cloud-provider-openstack-test/post.yaml
+    nodeset: ubuntu-xenial-citynetwork
+    secrets:
+      - citynetwork_credentials
+    vars:
+      k8s_os_provider_src_dir: '{{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack'
+      k8s_src_dir: '{{ ansible_user_dir }}/src/k8s.io/kubernetes'
+      k8s_log_dir: '{{ ansible_user_dir }}/workspace/logs/kubernetes'
+      kubectl: '{{ ansible_user_dir }}/src/k8s.io/kubernetes/cluster/kubectl.sh'
+
+- job:
+    name: cloud-provider-openstack-unittest-citynetwork
+    parent: cloud-provider-openstack-test-citynetwork
+    description: |
+      Run unit test of cloud-provider-openstack
+    run: playbooks/cloud-provider-openstack-unittest/run.yaml
+    secrets:
+      - citynetwork_credentials
+
+- job:
+    name: cloud-provider-openstack-acceptance-test-k8s-cinder-citynetwork
+    parent: cloud-provider-openstack-test-citynetwork
+    description: |
+      Run cinder in-tree acceptance tests of cloud-provider-openstack
+    run: playbooks/cloud-provider-openstack-acceptance-test-k8s-cinder/run.yaml
+    post-run: playbooks/cloud-provider-openstack-acceptance-test-k8s-cinder/post.yaml
+    secrets:
+      - citynetwork_credentials
+
+- job:
+    name: cloud-provider-openstack-acceptance-test-e2e-conformance-citynetwork
+    parent: cloud-provider-openstack-test-citynetwork
+    description: |
+      Run Kubernetes E2E Conformance tests against Kubernetes master
+    vars:
+      go_version: '1.12.1'
+    run: playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+    post-run: playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/post.yaml
+    secrets:
+      - citynetwork_credentials
+      - gcp_account
+      - dockerhub
+
+- job:
+    name: cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.10-citynetwork
+    parent: cloud-provider-openstack-acceptance-test-e2e-conformance-citynetwork
+    description: |
+      Run Kubernetes E2E Conformance tests against Kubernetes v1.10
+    vars:
+      go_version: '1.9.3'
+      k8s_version: 'release-1.10'
+
+- job:
+    name: cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.11-citynetwork
+    parent: cloud-provider-openstack-acceptance-test-e2e-conformance-citynetwork
+    description: |
+      Run Kubernetes E2E Conformance tests against Kubernetes v1.11
+    vars:
+      go_version: '1.10.3'
+      k8s_version: 'release-1.11'
+
+- job:
+    name: cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.12-citynetwork
+    parent: cloud-provider-openstack-acceptance-test-e2e-conformance-citynetwork
+    description: |
+      Run Kubernetes E2E Conformance tests against release-1.12 branch of Kubernetes
+    vars:
+      go_version: '1.10.8'
+      k8s_version: 'release-1.12'
+    tags:
+      - Category:Cloud
+      - Project:kubernetes/cloud-provider-openstack
+      - Application:cloud-provider-openstack@release-1.12
+      - Application:Kubernetes@release-1.12
+      - Application:Docker.io@v18.09
+      - Application:Etcd@v3.3.10
+      - Application:Go@1.10.8
+      - OS:ubuntu-xenial
+      - Arch:x86_64
+      - BuildType:Integration test
+
+- job:
+    name: cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.13-citynetwork
+    parent: cloud-provider-openstack-acceptance-test-e2e-conformance-citynetwork
+    description: |
+      Run Kubernetes E2E Conformance tests against release-1.13 branch of Kubernetes
+    vars:
+      go_version: '1.12'
+      k8s_version: 'release-1.13'
+    tags:
+      - Category:Cloud
+      - Project:kubernetes/cloud-provider-openstack
+      - Application:cloud-provider-openstack@release-1.13
+      - Application:Kubernetes@release-1.13
+      - Application:Docker.io@v18.09
+      - Application:Etcd@v3.3.10
+      - Application:Go@1.12
+      - OS:ubuntu-xenial
+      - Arch:x86_64
+      - BuildType:Integration test
+
+- job:
+    name: cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.14-citynetwork
+    parent: cloud-provider-openstack-acceptance-test-e2e-conformance-citynetwork
+    description: |
+      Run Kubernetes E2E Conformance tests against release-1.14 branch of Kubernetes
+    vars:
+      go_version: '1.12.1'
+      k8s_version: 'release-1.14'
+    tags:
+      - Category:Cloud
+      - Project:kubernetes/cloud-provider-openstack
+      - Application:cloud-provider-openstack@release-1.14
+      - Application:Kubernetes@release-1.14
+      - Application:Docker.io@v18.09
+      - Application:Etcd@v3.3.10
+      - Application:Go@1.12.1
+      - OS:ubuntu-xenial
+      - Arch:x86_64
+      - BuildType:Integration test
+
+- job:
+    name: cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.15-citynetwork
+    parent: cloud-provider-openstack-acceptance-test-e2e-conformance-citynetwork
+    description: |
+      Run Kubernetes E2E Conformance tests against release-1.15 branch of Kubernetes
+    vars:
+      go_version: '1.12.1'
+      k8s_version: 'release-1.15'
+    tags:
+      - Category:Cloud
+      - Project:kubernetes/cloud-provider-openstack
+      - Application:cloud-provider-openstack@release-1.15
+      - Application:Kubernetes@release-1.15
+      - Application:Docker.io@v18.09
+      - Application:Etcd@v3.3.10
+      - Application:Go@1.12.1
+      - OS:ubuntu-xenial
+      - Arch:x86_64
+      - BuildType:Integration test
+
+- job:
+    name: cloud-provider-openstack-acceptance-test-csi-cinder-citynetwork
+    parent: cloud-provider-openstack-test-citynetwork
+    description: |
+      Run cinder csi acceptance tests of cloud-provider-openstack
+    run: playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
+    post-run: playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/post.yaml
+    secrets:
+      - citynetwork_credentials
+
+- job:
+    name: cloud-provider-openstack-acceptance-test-lb-octavia-citynetwork
+    parent: cloud-provider-openstack-test-citynetwork
+    description: |
+      Run lb acceptance tests of cloud-provider-openstack
+    run: playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
+    post-run: playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/post.yaml
+    secrets:
+      - citynetwork_credentials

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -25,6 +25,12 @@
         label: ubuntu-xenial-vexxhost
 
 - nodeset:
+    name: ubuntu-xenial-citynetwork
+    nodes:
+      - name: ubuntu-xenial-citynetwork
+        label: ubuntu-xenial-citynetwork
+
+- nodeset:
     name: ubuntu-xenial-arm64
     nodes:
       - name: ubuntu-xenial-arm64

--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -594,6 +594,92 @@
           1v4W0a/B+TwsJCNLC4lq540P2QlTmidXwRQ/PwUFd8/HdHUnQSU3q+0Msf+xBwZVcsjz2
           GLSzc1uDIvsbfx7zWRq4AKCslrE5dVrstLG/Z1MZWBRNKZzzW6OtzToMjLcwJE=
 
+- secret:
+    name: citynetwork_credentials
+    data:
+      auth_type: password
+      identity_api_version: "3"
+      volume_api_version: "2"
+      network_api_version: "2.0"
+      interface: public
+      auth_url: !encrypted/pkcs1-oaep
+        - NxhqVagoa9Aj5KWdTyWFN2mvoIXw1Nj3nARE27JJlCYa2IkTOgRtftLoKHGgn1l2Kys6d
+          klQc0fv5KnlL2GF0P0zBrBbiFu20ONsiZ0uEY1/t2/wJ+Jfsp4RtW3jTcBsF33HH6hN2j
+          VJW91HidhSx+CMkIMv2ldk/i4m1Zxoq5ux9VgMeRs7jsAtOcYmAfxk/dbdvWfE+wEoRxK
+          quvql+uzz6G4IftTXtkBQNOl8XThbeRUcnEfwodJJe5ISB7p01y6MGImtLJZYo68KF0pK
+          LNQTHO0aHcZnm9slJJu4p3WVCla40xVCmSpxWPtqVWcpjqXw+3+qLN72Cqf51Cnr26m2T
+          a3kUx65ZQn37cVYDxfxshJghqTTqDD8lTXYvQkxfOAoJVcbXS83R1CL20G5PvrAY+mZT8
+          BSjicSnKs44Hge9ag3F/Q8tMbNK9xjgwPZPAkKhOW3K5TELbkLxXyKliRx0JtJ42diNd+
+          jYTLPKeKRAtzNtzsOzsHefxyuGkBoxjjhu4J3pe9x94hJzIYeRkj1ekT4+33CoZ1Cf2Sf
+          ZbnCtMG3166fddm0sTZLy5O3lIGNuA2+rjOQraMAaEHPOKFVDp2yZ7INL567Ky4yoFjaq
+          ersC05XCVGF19vLv8VpNbiD+aO0QGPaqiSuEFbUUpTBDlHmhWS3DZHRgX+ZJkc=
+      project_name: !encrypted/pkcs1-oaep
+        - HJcy84cGG+84zxWyP9WFcsYDbVgRC1Ro4BF48H5YQqxyGBh//5FdQoHE5J6dAloy/Q4Q/
+          QjpHwnEbQQYGOqoy853Cb6xK5ghMFi1xCwqgOINjCStLE95ZgC1FtfomzWC2gEd/jjCXr
+          T+m+3cFwUSdM1RpZzdHpv7TJGGKpRneJ+BM45Y+Ip4MPp4bASDgN+y49Re0nevLC4ig/F
+          GTUjZfhSXfWtNjkJNuIfSXcEHbRyiIpuLbJ+V+GOzkj92QhXgaTr+imXyJaCX2CO+JM+T
+          CpIWBuAFmZ/hHs1p8ogFcb5fWchN8ZwmC4dMrTDXq6DBlPZPdKah+u/FDct+vpeDT9HVs
+          xa/tp637DH2k5l4pKNk9UlrZ5t3HhbbN6eVVcQTHE6XCvbHUEbMLYoRtaDiio1vdv4P0e
+          GU+O0xcJJBjBxQoke2Rxt0l1WA0wvOF14R4CYx5KEIABoUImJFBQ3lWisinK+aEnHC/Qu
+          sZdKzaSesHt380Mnxlo/lh2SA1Bqu7lNZ/La0KlZ8Vz0OFFW95OcRTQXt/SBnqnO6TAX5
+          Qvtk5lWope5xkrsk/Ak/MOprqsg35rfuhdczIdq/AexWvvh4D1if7NWsAUmHhNj3Xbo9E
+          XIH2HNSVnB+n95CH6mvYQKg5SZZEryQCYu8Zag+1f9HHkrqlcMhR9PN+/O5i2w=
+      project_domain_name: !encrypted/pkcs1-oaep
+        - K9mbAWFK1Cw+ySEaEbdxEFc6HL12zjMp4aJ8fICh+e5/Q5F3wnwdyLvSt7EF+G4hmOrOM
+          n+nGp9JHedsPjiIFzbB2iYK3J93WJGLwnSsyvFqyPukf8YeuBlbKFQog3rVKwKqaSmDew
+          8neDeuXnLQrAGSgCaFe0efs+nnh2dFxR1pRiXVhHDSdoas0K9rj9YkvDTB1j5hz2oc59x
+          F4AfO5OhEiSZStykoJhWR2u8FHLwDGIFCMZlQJtmj4syAK+pS0W8+DdDHNAKD34y9kLeN
+          69n7n6v2ceHKxCHWGl/ZCB8pL68uhN925+fnu8LWrd6tVcOxffdv4czy4nfh6FAlyt79Q
+          9HR2CQ+tvPl90KMoW6TUDq9kWov7Zar4OttUd/qan1DFL3/W4mfRPmsCTd1upVhDLp4Se
+          e2TzcPszt/Ovlz/+enp+QuUSEk1LHLJFlwIVaSZ1RxsWeFriu64U/ah2uE3jnjd5SEyUY
+          eIxXk5yLGYjd98LvRez1zrqCgJRm1/FvhMLQstOijHXwzVxvl2mk2yfEp9rCdDyg/xgF7
+          LFwXkAMRn9htZTKDLJ5dGXcOb7s3MQpT9E1wrJdE3BzzPDb/W/7mGtrErTyKypWOjVxco
+          e+Slzy6ldDT1Eo8ooiDn5c/IRN6xgsipGkM44BObCCx6Hgqnqpjyvsl5fsMG5U=
+      username: !encrypted/pkcs1-oaep
+        - jXilzHRmWz0mecZR/eAXkS1qW4I3BqTBnGE/tZW7RzarYP8wpsiGw1gsT2UQihd+78D4B
+          pYNC/SZVNxMiTGmtMPdgQ4vfuqTenrLSEAiF002GqovoIrydcGKRV23CWDBZjRWQYcafp
+          QIbWbOZqOIGNVyG9eoa9/xnylCP2+xk9OrLcGIsfrTHdj4ANAwKmRbxN/EAakZ+v7n3fS
+          rQOPiY/SL2J5dcWpB5MpPU0yBJAnF+HrSAIB3Pj3GxMaCWYR35ear48J+2klNPjNC3hyg
+          hk+XzC60ZSgXihezh+aw1ZxC5ezPHWSGbW/4SKAYtOE6LDfcgPa/jRdgbye3F/YnEwIbo
+          zu9D/exFmtM3VGdhAFCpIQo6kFDsbvIlt4wOKJsfYsUijm/b1kqBQHjAHWPMqPaEpSFp6
+          Af5PrSxAR88o9LYMyC5GDKqgk7jAaXEFvcxXTeOu8FQlSlzqFFjc5pozUu+jRNRE1f294
+          CuqSUtOBOs9lHW6+t59VlqL12I+PrCoMFIZr+OgAzWO+0dtYvqsMBH2ZBE0+EFpG4UyMA
+          pxQyQu/XOLL+NuW3ZTLajsq2cGlvbPV9HSgJfxcnwf7sg1yswm55tfim7J4tn8q/rGQ3n
+          vmOw5fmuE5VU0yh3Ebfr4jy4WIRnUZ0KK0/NrxU5hsBdt6eUoIKmX+VlElUzpE=
+      user_domain_name: !encrypted/pkcs1-oaep
+        - AzkB6pONDNG/NcsWUhZWUs5edhiCAUjSUa9VhtxY7mJnZdzAr5uYlZx8ilxLdOo0yL3zM
+          hLOANENbBFK7d8IBi2vULU110JOs9jT9IXN4hNm95ooyADdFn/ylUItbpXecZ2r1bN9ix
+          AxZ0MPgy0UMNR36A3jsBJWopR966UFIWwX481mCMRIxraeJ17pSGJQk9vUB5qfX4cdcWQ
+          TU8+PiqxByrH07cwYpncPqxaGbH1KjmxbWDBgEyFB657G8B2zdLu6xhls9l1uviFfKDMy
+          MutudaurG06mzwUfqQ59kLTBLAfBmjADsnCyWVhiInqNqHXQsEdLSlSlPXfWXkdGdFzPv
+          qmUO+Lu9b90uEDG+EX9/JK/L1FDVELHJ6D2J6mMUjPFuoIuomt+2AXHTtfP89nIN9Nh6j
+          HTAVF11ZKdQiLQRrz8Avmqeola9ODl3WkYB8+cn8M/zhDmyTmjf9Yj4AVvE1+Umz9bzHF
+          ulSe3rd+vfgIxrYClWKFfoEgcsch4w54HdnwQB0Nsjg6pO/kH98OFP3DSc7lX5uFTuvbm
+          dxhI7ur23p1VjBz8zR7h4gpSeJ+SkVkMLfJlGffjN2jSazRdu3sPoXKrojM38Awll9DRB
+          PMquPR61CECzPDRWAqKtTzujJz6rxF6fW5PEijW2CnKMfktPeRb3ATNOBbpTdo=
+      password: !encrypted/pkcs1-oaep
+        - biRDbjAP8irN6cZ3uGOSZUr7815IhIsmvg7BSyOmx+nq0Qs/LfRgmPBV6R3IcG4Uo5SS5
+          WNz99+j/NJmKLK35rAYd00XCKaJKa+hWEChn31odc3+g3tw8YBDMjyClHVwjwpEu7Dt7K
+          sSmHgiacxJdZ55zYmG5J/mEEOMdNivapdoQQoTnzdFdMknSN2+INk+0FTanvTdyac64e+
+          p+D2WbVRaYYEwtrqulGSInr8yhwA9YrdupjK9fzPZjBTpXgEwY/YgprESNq9GWD2fwEMz
+          pZiCe9WbOpXIi40EIoGX4j7KmQxcv1EBMQ30F2urIwAmHH0R8hir2Ot50x0cJEePKcYWL
+          PBOEdE+PMUFNc7INy86K1zFJVQdAtCzxKXJm7BWzsuxRJ4Y/6lXgZYP/yK3fUut44whqf
+          QGB7s+Wb2e1lFovTVQ7TFqj9nfydgI5t1H0JpT3FtbS7Ft/ZI0vjCLVGCUlh++O59mswK
+          KqTCdemwf9OB9D7s9wp0lCANGOAihNTgi7ZE4I38m7xrWlCiDLyEVCFMZc5LsNoCwwpKO
+          ZRauYE3JFyrzFSBg9sfbJwdoUr+bg6+K68LiZOH3NPtNs+mFbI91eI5V72wjIXkSxbXeD
+          oPvFNPNdPX7bcQevrv0KGdiTLfpSFl2fGRypwm5s066Fzq4Yq2+1+FPjvNIo24=
+      region_name: !encrypted/pkcs1-oaep
+        - Gh1LIMfvvGuwSQt6vS6KeQ1z/s3Uogkwk+Yyz99fMBu13b/g30jbvSN43JvJ21VO2a8Zj
+          3aSpViJLlxboHJoZsPCW0BoCwCtEHLyQ09W9+ZGNGkofJH7I1HTYmKCqhClvFttH4nF8W
+          gdjNzkvX8mYogjSyB3H/IveiRr1xCEhE8AKtx96mcLzNnqULSpPK5uTL4OxF/E1sIVfLj
+          KwguOZjgomr/lRq0huMj0I5pbmHOfFgSUwV7S/Kpv2ud7vWoTsEpFN51UVqioS53oyeap
+          S8o3gCnV9qE5Znz6ej8aq8o/EG/mvmHoaE5+AyonPoy1e453eJxHC0kzVEHXWdhh1x1hA
+          qRfocU/2o+7kYLSwScJm0I4mH1rXv6FaBfK+FMk1sK2JythZ16CG8A875Wa9MTrQJNPpk
+          /rniLwKRX7USp99S0zCVc/s/VM2K3413ut0/TB3lKQKLK0Rcv3UGWD3fLa090odu9WZ0o
+          j2jqXU3btkM1N4gjEPfXGO10XEWMr8/V27YqC0V3JSh1nnPTmxlN3NToUmErrWUXPxnGV
+          2OZlyxKdvwystyBFz62t5FoDH1O1Tp8V5OKhU+6oQrQDwtD5SpeNTBGorBJ2NencFI0xR
+          YowOlUFy1+n9s+N+PWpCG71Me9M72tiWw+wUbgGPkzyWrBUlyLCOz++aFsjknQ=
+
 # Google cloud account info
 - secret:
     name: gcp_account


### PR DESCRIPTION
We want to move cpo related jobs from vexxhost to citynetwork. Before moving, we should test the jobs works well on citynetwork. This PR add temp jobs for testing. After testing well, we'll adopt the change to the offical jobs and remove the temp ones.

Related-Bug: theopenlab/openlab#321