### PR TITLE
Fix cpo lb job

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
@@ -31,7 +31,7 @@
           [LoadBalancer]
           use-octavia = true
           floating-network-id = $(openstack network list --external -f value -c ID | head -n 1)
-          subnet-id = $(openstack network list --internal -f value -c Subnets | head -n 1)
+          subnet-id = $(openstack network list --internal -f value -c Subnets | head -n 1 | cut -d "," -f1)
           [BlockStorage]
           bs-version = v3
           ignore-volume-az = yes


### PR DESCRIPTION
There is a case that a network contains more than one subnet, in such case, we should select one from the list.

Related-Bug: #theopenlab/openlab#321