### PR TITLE
Add vexxhost lb label

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -717,7 +717,7 @@
       Run lb acceptance tests of cloud-provider-openstack
     run: playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
     post-run: playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/post.yaml
-    nodeset: ubuntu-xenial-vexxhost
+    nodeset: ubuntu-xenial-vexxhost-lb
     vars:
       cloud_name: vexxhost
     secrets:

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -25,6 +25,12 @@
         label: ubuntu-xenial-vexxhost
 
 - nodeset:
+    name: ubuntu-xenial-vexxhost-lb
+    nodes:
+      - name: ubuntu-xenial-vexxhost-lb
+        label: ubuntu-xenial-vexxhost-lb
+
+- nodeset:
     name: ubuntu-xenial-citynetwork
     nodes:
       - name: ubuntu-xenial-citynetwork


### PR DESCRIPTION
Now vexxhost provider is only used for arm and cpo lb jobs

Close: theopenlab/openlab#321