### PR TITLE
Use python3 for cpo test

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/post.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/post.yaml
@@ -24,7 +24,7 @@
               PIPELINE_LOGS_DIR='pr-logs'
           fi
           # upload e2e log to google storage
-          python upload_e2e.py --junit=$LOG_DIR/junit*.xml --log=$LOG_DIR/e2e.log \
+          python3 upload_e2e.py --junit=$LOG_DIR/junit*.xml --log=$LOG_DIR/e2e.log \
               --bucket=gs://k8s-conformance-openstack/$PIPELINE_LOGS_DIR/ci-'{{ zuul.job }}' \
               --key-file='{{ hostvars[inventory_hostname]["gcp_key_file"] }}'
         executable: /bin/bash

--- a/playbooks/kind-integration-test-arm64/post.yaml
+++ b/playbooks/kind-integration-test-arm64/post.yaml
@@ -24,7 +24,7 @@
               PIPELINE_LOGS_DIR='pr-logs'
           fi
           # upload e2e log to google storage
-          python upload_e2e.py --junit=$LOG_DIR/junit*.xml --log=$LOG_DIR/e2e.log \
+          python3 upload_e2e.py --junit=$LOG_DIR/junit*.xml --log=$LOG_DIR/e2e.log \
               --bucket=gs://k8s-conformance-kind-arm64-openlab/$PIPELINE_LOGS_DIR/ci-'{{ zuul.job }}' \
               --key-file='{{ hostvars[inventory_hostname]["gcp_key_file"] }}'
         executable: /bin/bash


### PR DESCRIPTION
k8s test-infra now use python3 by default[1]. Update related jobs to py3 as well.

[1]: https://github.com/kubernetes/test-infra/commit/7b4a98f8addfbc2d3236476ca378bf9f2d4b0b7c