### PR TITLE
Add scala install step

### DIFF
--- a/roles/install-openjdk/defaults/main.yaml
+++ b/roles/install-openjdk/defaults/main.yaml
@@ -1,2 +1,4 @@
 ---
 java_version: '8'
+with_scala: false
+scala_version: '2.13.0'

--- a/roles/install-openjdk/tasks/main.yaml
+++ b/roles/install-openjdk/tasks/main.yaml
@@ -30,3 +30,39 @@
   args:
     executable: /bin/bash
   environment: '{{ global_env }}'
+
+- name: Install scala
+  shell: |
+    set -xe
+    wget https://downloads.lightbend.com/scala/{{ scala_version }}/scala-{{ scala_version }}.tgz
+    tar -zxvf scala-{{ scala_version }}.tgz -C /usr/local
+  args:
+    executable: /bin/bash
+  when:
+    - with_scala|default(false)|bool
+
+- name: Set scala env vars
+  set_fact:
+    scala_env:
+      PATH: '/usr/local/scala-{{ scala_version }}/bin:{{ ansible_env.PATH }}'
+  no_log: yes
+  when:
+    - with_scala|default(false)|bool
+
+- name: Merge scala env vars into global env
+  set_fact:
+    global_env: '{{ global_env | combine(scala_env) }}'
+  no_log: yes
+  when:
+    - with_scala|default(false)|bool
+
+- name: Show installed scala info
+  shell: |
+    set -ex
+    which scala
+    scala -version
+  args:
+    executable: /bin/bash
+  environment: '{{ global_env }}'
+  when:
+    - with_scala|default(false)|bool


### PR DESCRIPTION
Now many project use scala, it's good to add a common role.Since scala depends on java, add the install step inner openjdk role. Users can install scala after openjdk with the var `with_scala`