### PR TITLE
Add root permission for /etc/hosts

### DIFF
--- a/roles/prepare-workspace/tasks/main.yml
+++ b/roles/prepare-workspace/tasks/main.yml
@@ -17,8 +17,11 @@
   shell: hostname
   register: real_hostname
 
-- name: Update the /etc/hosts file with node name if possible
-  lineinfile:
-    path: "/etc/hosts"
-    regexp: "^127.0.0.1"
-    line: "127.0.0.1 {{ real_hostname.stdout }} localhost"
+- hosts: all
+  become: yes
+  tasks:
+    - name: Update the /etc/hosts file with node name if possible
+      lineinfile:
+        path: "/etc/hosts"
+        regexp: "^127.0.0.1"
+        line: "127.0.0.1 {{ real_hostname.stdout }} localhost"


### PR DESCRIPTION
When update /etc/hosts file, it should has root permission.