### PR TITLE
Fix scala 2.11.0 bug

### DIFF
--- a/roles/install-openjdk/tasks/main.yaml
+++ b/roles/install-openjdk/tasks/main.yaml
@@ -58,7 +58,6 @@
 
 - name: Show installed scala info
   shell: |
-    set -ex
     which scala
     scala -version
   args:


### PR DESCRIPTION
scala 2.11.0 -version return code is not 0 even there is no error.

Remove set -ex to make the job happy