### PR TITLE
Fix CPO job error

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/post.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/post.yaml
@@ -24,7 +24,7 @@
               PIPELINE_LOGS_DIR='pr-logs'
           fi
           # upload e2e log to google storage
-          python3 upload_e2e.py --junit=$LOG_DIR/junit*.xml --log=$LOG_DIR/e2e.log \
+          python3.7 upload_e2e.py --junit=$LOG_DIR/junit*.xml --log=$LOG_DIR/e2e.log \
               --bucket=gs://k8s-conformance-openstack/$PIPELINE_LOGS_DIR/ci-'{{ zuul.job }}' \
               --key-file='{{ hostvars[inventory_hostname]["gcp_key_file"] }}'
         executable: /bin/bash

--- a/playbooks/cloud-provider-openstack-test/pre.yaml
+++ b/playbooks/cloud-provider-openstack-test/pre.yaml
@@ -2,3 +2,12 @@
   become: yes
   roles:
     - move-k8s-repo-to-k8s-specific-dir
+  tasks:
+    - name: Install python3.7
+      shell:
+        cmd: |
+          set -ex
+          add-apt-repository -y ppa:jonathonf/python-3.7
+          apt update
+          apt install -y python3.7
+        executable: /bin/bash


### PR DESCRIPTION
upload_e2e.py uses subprocess.check_out(...encoding...). The encoding parameter is added in python3.6, but the default version in ubuntu16.04 is python3.5.

Install and use python3.7 to fix the issue.