### PR TITLE
Fix ansible openstacksdk mitaka periodic job

### DIFF
--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -33,7 +33,7 @@
       add-apt-repository ppa:deadsnakes/ppa -y
       apt-get update
       apt-get install python3.5 python3.5-dev libssl-dev -y
-      sudo update-alternatives --install $(which python3) python3 $(which python3.5) 1
+      update-alternatives --install $(which python3) python3 $(which python3.5) 1
 
       # Because the pip10 cannot uninstall/upgrade the pre-installed distutils packages
       # see: https://github.com/pypa/pip/issues/4805

--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -27,6 +27,14 @@
     cmd: |
       set -e
       set -x
+      # As openstack/requirements already upgrade requests to 2.22.0,
+      # but didn't provider a 2.22.0 version for python34 which we used.
+      # Install python3.5
+      add-apt-repository ppa:deadsnakes/ppa -y
+      apt-get update
+      apt-get install python3.5 python3.5-dev libssl-dev -y
+      sudo update-alternatives --install $(which python3) python3 $(which python3.5) 1
+
       # Because the pip10 cannot uninstall/upgrade the pre-installed distutils packages
       # see: https://github.com/pypa/pip/issues/4805
       sed -i '/"Running gate_hook"/ a\


### PR DESCRIPTION
Openstack requirements already update the requests version to 2.22.0,
but pypi only has this specific version for python27 python35 python36
and python37. And currently we use py34 in our jobs. So we need to
upgrade the python version from py34 to py35.

test success in allinone:
https://github.com/bzhaoopenstack/ansible/pull/1