### PR TITLE
Add new nodeset for cpo multi node job

### DIFF
--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -74,3 +74,13 @@
           - k8s-node-2
           - k8s-node-3
           - k8s-node-4
+
+- nodeset:
+    name: ubuntu-xenial-k8s-cluster-cpo
+    nodes:
+      - name: k8s-master
+        label: ubuntu-xenial-citynetwork
+      - name: k8s-node-1
+        label: ubuntu-xenial-citynetwork
+      - name: k8s-node-2
+        label: ubuntu-xenial-citynetwork


### PR DESCRIPTION
Add a new nodeset for cpo multi node job, it includes 3 nodes. One for k8s master and the other two for k8s node.

Relate-bug: theopenlab/openlab#342