### PR TITLE
Use GOPROXY in CPO conformance tests

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -104,7 +104,8 @@
 
           # Build kubetest
           export GO111MODULE=on
-          go get -u k8s.io/test-infra/kubetest
+          export GOPROXY=https://proxy.golang.org
+          go get k8s.io/test-infra/kubetest
           # Build all binaries
           export KUBE_FASTBUILD=true
           export KUBERNETES_CONFORMANCE_TEST=y


### PR DESCRIPTION
use GOPROXY for faster downloading of go modules and fix conformance job.