### PR TITLE
Don't set -o for spark arm64 job

### DIFF
--- a/playbooks/spark-unit-test-arm64/run.yaml
+++ b/playbooks/spark-unit-test-arm64/run.yaml
@@ -10,9 +10,9 @@
       shell: |
         set -xo pipefail
         # build and test spark
-        ./build/mvn -DskipTests clean package 2>&1 | tee "{{ ansible_user_dir }}/workspace/logs/spark_build_original.log"
+        ./build/mvn -DskipTests clean package 2>&1 | sudo tee "{{ ansible_user_dir }}/workspace/logs/spark_build_original.log"
         # mvn test will failed due to the leveldbjni has no aarch64 supporting
-        ./build/mvn test 2>&1 | tee "{{ ansible_user_dir }}/workspace/logs/spark_test_original.log"
+        ./build/mvn test 2>&1 | sudo tee "{{ ansible_user_dir }}/workspace/logs/spark_test_original.log"
       args:
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'
@@ -22,7 +22,7 @@
     - name: 'Step2: Build and run unit tests for apache spark after fixing errors'
       shell:
         cmd: |
-          set -exo pipefail
+          set -ex
 
           # fix kafka authfail tests
           sudo sed -i -e 's/^127.0.0.1 .*$/127.0.0.1 localhost '$(hostname)'/g' /etc/hosts
@@ -31,8 +31,8 @@
           wget https://repo1.maven.org/maven2/org/openlabtesting/leveldbjni/leveldbjni-all/1.8/leveldbjni-all-1.8.jar
           mvn install:install-file -DgroupId=org.fusesource.leveldbjni -DartifactId=leveldbjni-all -Dversion=1.8 -Dpackaging=jar -Dfile=leveldbjni-all-1.8.jar
 
-          ./build/mvn clean install -DskipTests -Phadoop-{{ hadoop_version }} -Pyarn -Phive -Phive-thriftserver -Pkinesis-asl -Pmesos 2>&1 | tee "{{ ansible_user_dir }}/workspace/logs/spark_build.log"
-          ./build/mvn test -Phadoop-{{ hadoop_version }} -Pyarn -Phive -Phive-thriftserver -Pkinesis-asl -Pmesos 2>&1 | tee "{{ ansible_user_dir }}/workspace/logs/spark_test.log"
+          ./build/mvn clean install -DskipTests -Phadoop-{{ hadoop_version }} -Pyarn -Phive -Phive-thriftserver -Pkinesis-asl -Pmesos 2>&1 | sudo tee "{{ ansible_user_dir }}/workspace/logs/spark_build.log"
+          ./build/mvn test -Phadoop-{{ hadoop_version }} -Pyarn -Phive -Phive-thriftserver -Pkinesis-asl -Pmesos 2>&1 | sudo tee "{{ ansible_user_dir }}/workspace/logs/spark_test.log"
 
         chdir: '{{ zuul.project.src_dir }}'
         executable: /bin/bash


### PR DESCRIPTION
The job will exit if we set -o option due to the
zinc error which we should ignore.

Related-Bug: theopenlab/openlab#316