### PR TITLE
Split the periodic pipeline to a single period

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -339,6 +339,176 @@
     failure:
       mysql:
 
+# For limited testing resource, we split the periodic jobs into a single timer
+# trigger for saving resources.
+- pipeline:
+    name: periodic-0
+    description: |
+      Jobs in this queue are triggered on a timer. UTC-0 00:00
+    manager: independent
+    precedence: high
+    trigger:
+      timer:
+        - time: '0 0 * * *'
+    success:
+      mysql:
+    failure:
+      mysql:
+
+- pipeline:
+    name: periodic-2
+    description: |
+      Jobs in this queue are triggered on a timer. UTC-0 02:00
+    manager: independent
+    precedence: high
+    trigger:
+      timer:
+        - time: '0 2 * * *'
+    success:
+      mysql:
+    failure:
+      mysql:
+
+- pipeline:
+    name: periodic-4
+    description: |
+      Jobs in this queue are triggered on a timer. UTC-0 04:00
+    manager: independent
+    precedence: high
+    trigger:
+      timer:
+        - time: '0 4 * * *'
+    success:
+      mysql:
+    failure:
+      mysql:
+
+- pipeline:
+    name: periodic-6
+    description: |
+      Jobs in this queue are triggered on a timer. UTC-0 06:00
+    manager: independent
+    precedence: high
+    trigger:
+      timer:
+        - time: '0 6 * * *'
+    success:
+      mysql:
+    failure:
+      mysql:
+
+- pipeline:
+    name: periodic-8
+    description: |
+      Jobs in this queue are triggered on a timer. UTC-0 08:00
+    manager: independent
+    precedence: high
+    trigger:
+      timer:
+        - time: '0 8 * * *'
+    success:
+      mysql:
+    failure:
+      mysql:
+
+- pipeline:
+    name: periodic-10
+    description: |
+      Jobs in this queue are triggered on a timer. UTC-0 10:00
+    manager: independent
+    precedence: high
+    trigger:
+      timer:
+        - time: '0 10 * * *'
+    success:
+      mysql:
+    failure:
+      mysql:
+
+- pipeline:
+    name: periodic-12
+    description: |
+      Jobs in this queue are triggered on a timer. UTC-0 12:00
+    manager: independent
+    precedence: high
+    trigger:
+      timer:
+        - time: '0 12 * * *'
+    success:
+      mysql:
+    failure:
+      mysql:
+
+- pipeline:
+    name: periodic-14
+    description: |
+      Jobs in this queue are triggered on a timer. UTC-0 14:00
+    manager: independent
+    precedence: high
+    trigger:
+      timer:
+        - time: '0 14 * * *'
+    success:
+      mysql:
+    failure:
+      mysql:
+
+- pipeline:
+    name: periodic-16
+    description: |
+      Jobs in this queue are triggered on a timer. UTC-0 16:00
+    manager: independent
+    precedence: high
+    trigger:
+      timer:
+        - time: '0 16 * * *'
+    success:
+      mysql:
+    failure:
+      mysql:
+
+- pipeline:
+    name: periodic-18
+    description: |
+      Jobs in this queue are triggered on a timer. UTC-0 18:00
+    manager: independent
+    precedence: high
+    trigger:
+      timer:
+        - time: '0 18 * * *'
+    success:
+      mysql:
+    failure:
+      mysql:
+
+- pipeline:
+    name: periodic-20
+    description: |
+      Jobs in this queue are triggered on a timer. UTC-0 20:00
+    manager: independent
+    precedence: high
+    trigger:
+      timer:
+        - time: '0 20 * * *'
+    success:
+      mysql:
+    failure:
+      mysql:
+
+- pipeline:
+    name: periodic-22
+    description: |
+      Jobs in this queue are triggered on a timer. UTC-0 22:00
+    manager: independent
+    precedence: high
+    trigger:
+      timer:
+        - time: '0 22 * * *'
+    success:
+      mysql:
+    failure:
+      mysql:
+
 - pipeline:
     name: recheck-designate
     description: |

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -36,17 +36,6 @@
         - openstacksdk-ansible-v2.8.0-functional-devstack-mitaka:
             branches: devel
 
-- project:
-    name: apache/spark
-    periodic-0/12:
-      jobs:
-        - spark-integration-test-kubeadm-k8s-v1.14.0:
-            branches: master
-        - spark-integration-test-minikube-k8s-v1.13.3:
-            branches: master
-        - spark-master-unit-test-hadoop-2.7-arm64:
-            branches: master
-
 ####################### periodic jobs on 02:00/14:00 ##########################
 - project:
     name: terraform-providers/terraform-provider-openstack
@@ -78,7 +67,7 @@
 
 - project:
     name: containerd/containerd
-    periodic-2/14:
+    periodic-14:
       jobs:
         - containerd-build-arm64:
             branches: master
@@ -114,7 +103,7 @@
 
 - project:
     name: envoyproxy/envoy
-    periodic-4/16:
+    periodic-16:
       jobs:
         - envoy-build-arm64:
             branches: master
@@ -141,14 +130,14 @@
 
 - project:
     name: kubernetes-sigs/kind
-    periodic-6/18:
+    periodic-6:
       jobs:
         - kind-integration-test-arm64:
             branches: master
 
 - project:
     name: apache/hive
-    periodic-6/18:
+    periodic-18:
       jobs:
         - hive-build-arm64:
             branches: master
@@ -194,10 +183,21 @@
 
 - project:
     name: apache/hadoop
-    periodic-8/20:
+    periodic-8:
       jobs:
         - hadoop-build-arm64:
             branches: trunk
+
+- project:
+    name: apache/spark
+    periodic-20:
+      jobs:
+        - spark-integration-test-kubeadm-k8s-v1.14.0:
+            branches: master
+        - spark-integration-test-minikube-k8s-v1.13.3:
+            branches: master
+        - spark-master-unit-test-hadoop-2.7-arm64:
+            branches: master
 
 ####################### periodic jobs on 10:00/22:00 ##########################
 - project:
@@ -239,7 +239,7 @@
 
 - project:
     name: apache/hbase
-    periodic-10/22:
+    periodic-22:
       jobs:
         - hbase-build-arm64:
             branches: master

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -36,6 +36,17 @@
         - openstacksdk-ansible-v2.8.0-functional-devstack-mitaka:
             branches: devel
 
+- project:
+    name: apache/spark
+    periodic-12:
+      jobs:
+        - spark-integration-test-kubeadm-k8s-v1.14.0:
+            branches: master
+        - spark-integration-test-minikube-k8s-v1.13.3:
+            branches: master
+        - spark-master-unit-test-hadoop-2.7-arm64:
+            branches: master
+
 ####################### periodic jobs on 02:00/14:00 ##########################
 - project:
     name: terraform-providers/terraform-provider-openstack
@@ -187,17 +198,6 @@
       jobs:
         - hadoop-build-arm64:
             branches: trunk
-
-- project:
-    name: apache/spark
-    periodic-20:
-      jobs:
-        - spark-integration-test-kubeadm-k8s-v1.14.0:
-            branches: master
-        - spark-integration-test-minikube-k8s-v1.13.3:
-            branches: master
-        - spark-master-unit-test-hadoop-2.7-arm64:
-            branches: master
 
 ####################### periodic jobs on 10:00/22:00 ##########################
 - project:


### PR DESCRIPTION
For saving arm resources, we only run 1 time per day for ARM periodic testing.