### PR TITLE
Do not create root permission directory under /home/zuul

### DIFF
--- a/playbooks/init-test/pre.yaml
+++ b/playbooks/init-test/pre.yaml
@@ -1,4 +1,15 @@
 - hosts: all
-  become: yes
   roles:
     - prepare-workspace
+  tasks:
+    - name: Get local hostname
+      become: yes
+      shell: hostname
+      register: result
+
+    - name: Set /etc/hosts with node name
+      become: yes
+      lineinfile:
+        path: "/etc/hosts"
+        regexp: "^127.0.0.1"
+        line: "127.0.0.1 {{ result.stdout }} localhost"

--- a/roles/prepare-workspace/tasks/main.yml
+++ b/roles/prepare-workspace/tasks/main.yml
@@ -12,13 +12,3 @@
   file:
     path: '{{ ansible_user_dir }}/workspace/test_results'
     state: directory
-
-- name: Get the local hostname
-  shell: hostname
-  register: real_hostname
-
-- name: Update the /etc/hosts file with node name if possible
-  lineinfile:
-    path: "/etc/hosts"
-    regexp: "^127.0.0.1"
-    line: "127.0.0.1 {{ real_hostname.stdout }} localhost"


### PR DESCRIPTION
- Create workspace directory with zuul permission
- Keep the role of "prepare-workspace" as its name show

Closes: theopenlab/openlab#359