### PR TITLE
Build hyperkube binary

### DIFF
--- a/roles/install-k8s/tasks/main.yaml
+++ b/roles/install-k8s/tasks/main.yaml
@@ -17,6 +17,6 @@
 
       # Build k8s cmd
       git clone https://github.com/kubernetes/kubernetes '{{ k8s_src_dir }}' -b '{{ k8s_version }}'
-      make -C '{{ k8s_src_dir }}' WHAT="cmd/kubectl cmd/kube-apiserver cmd/kube-controller-manager cmd/cloud-controller-manager cmd/kubelet cmd/kube-proxy cmd/kube-scheduler"
+      make -C '{{ k8s_src_dir }}' WHAT="cmd/kubectl cmd/hyperkube cmd/kube-apiserver cmd/kube-controller-manager cmd/cloud-controller-manager cmd/kubelet cmd/kube-proxy cmd/kube-scheduler"
     executable: /bin/bash
   environment: '{{ global_env }}'


### PR DESCRIPTION
hyperkube binary is removed from local-up-cluster.sh but still
used by at other places (golang.sh), so adding the same.