### PR TITLE
Add new pipeline for Flink mail trigger

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -1251,3 +1251,26 @@
       github:
         status: 'failure'
       mysql:
+
+- pipeline:
+    name: periodic-20-flink-mail
+    description: |
+      This pipeline is used for send Flink periodic job result to spefied
+      maillist for Apache Flink
+    manager: independent
+    precedence: high
+    trigger:
+      timer:
+        - time: '0 20 * * *'
+    success:
+      smtp:
+        from: info@openlabtesting.org
+        to: build@flink.apache.org
+        subject: Daily Flink ARM Cron Job Test Result - SUCCESS
+      mysql:
+    failure:
+      smtp:
+        from: info@openlabtesting.org
+        to: build@flink.apache.org
+        subject: Daily Flink ARM Cron Job Test Result - FAILED
+      mysql:

--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -1265,12 +1265,12 @@
     success:
       smtp:
         from: info@openlabtesting.org
-        to: build@flink.apache.org
+        to: builds@flink.apache.org
         subject: Daily Flink ARM Cron Job Test Result - SUCCESS
       mysql:
     failure:
       smtp:
         from: info@openlabtesting.org
-        to: build@flink.apache.org
+        to: builds@flink.apache.org
         subject: Daily Flink ARM Cron Job Test Result - FAILED
       mysql:


### PR DESCRIPTION
This PR add a new pipeline. It's used for sending Flink test result to flink official mail list