### PR TITLE
Fix lxml ARM error

### DIFF
--- a/playbooks/flink-end-to-end-test/post.yaml
+++ b/playbooks/flink-end-to-end-test/post.yaml
@@ -2,9 +2,7 @@
   become: yes
   tasks:
     - name: Install lxml
-      pip:
-        name: lxml
-        executable: pip3
+      shell: apt install python-lxml python3-lxml -y
 
     - name: Get Flink version
       xml:


### PR DESCRIPTION
lxml doesn't support ARM by default. Use Ubuntu packaged ones instead.