### PR TITLE
Use cp command instead of copy module

### DIFF
--- a/playbooks/flink-end-to-end-test/post.yaml
+++ b/playbooks/flink-end-to-end-test/post.yaml
@@ -14,7 +14,9 @@
       register: flink_version
 
     - name: Fetch e2e test log
-      copy:
-        src: "{{ ansible_user_dir }}/src/github.com/apache/flink/flink-dist/target/flink-{{ flink_version.matches[0]['{http://maven.apache.org/POM/4.0.0}version'] }}-bin/flink-{{ flink_version.matches[0]['{http://maven.apache.org/POM/4.0.0}version'] }}/log/"
-        dest: '{{ ansible_user_dir }}/workspace/'
-        remote_src: yes
+      shell:
+        cmd: |
+          cp -r "flink-dist/target/flink-{{ flink_version.matches[0]['{http://maven.apache.org/POM/4.0.0}version'] }}-bin/flink-{{ flink_version.matches[0]['{http://maven.apache.org/POM/4.0.0}version'] }}/log/" "{{ ansible_user_dir }}/workspace/"
+      args:
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'


### PR DESCRIPTION
copy module support copy remote dictionary only in ansible 2.8+. See: https://github.com/ansible/ansible/pull/43998

But zuul contains ansible < 2.8. So we should use cp command instead.