### PR TITLE
Update cpo e2e conformance jobs to run with latest release.

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -115,7 +115,7 @@
           export KUBE_FASTBUILD=true
           export KUBERNETES_CONFORMANCE_TEST=y
           # Go modules not supported by kubernetes before v1.15
-          if [ '{{ k8s_version }}' == 'release-1.13' ] || [ '{{ k8s_version }}' == 'release-1.14' ]; then
+          if [ '{{ k8s_version }}' == 'release-1.14' ]; then
             unset GO111MODULE
             unset GOSUMDB
             unset GOPROXY

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -683,6 +683,28 @@
       - BuildType:Integration test
 
 - job:
+    name: cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.16
+    parent: cloud-provider-openstack-acceptance-test-e2e-conformance
+    description: |
+      Run Kubernetes E2E Conformance tests against release-1.16 branch of Kubernetes
+    nodeset: ubuntu-xenial-citynetwork
+    vars:
+      go_version: '1.12.4'
+      k8s_version: 'release-1.16'
+      etcd_version: 'v3.3.15'
+    tags:
+      - Category:Cloud
+      - Project:kubernetes/cloud-provider-openstack
+      - Application:cloud-provider-openstack@release-1.16
+      - Application:Kubernetes@release-1.16
+      - Application:Docker.io@v18.09
+      - Application:Etcd@v3.3.15
+      - Application:Go@1.12.4
+      - OS:ubuntu-xenial
+      - Arch:x86_64
+      - BuildType:Integration test
+
+- job:
     name: cloud-provider-openstack-acceptance-test-standalone-cinder
     parent: cloud-provider-openstack-test
     description: |

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -103,12 +103,12 @@
       jobs:
         - cloud-provider-openstack-acceptance-test-e2e-conformance:
             branches: master
+        - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.16:
+            branches: release-1.16
         - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.15:
             branches: release-1.15
         - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.14:
             branches: release-1.14
-        - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.13:
-            branches: release-1.13
 
 - project:
     name: envoyproxy/envoy


### PR DESCRIPTION
This commit adds cpo e2e conformance job for 1.16 release and also removes
older releases than 1.14