### PR TITLE
Fix conformance jobs

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -108,14 +108,18 @@
           # go get kubetest is failing from k8s or cpo directory
           cd ..
           export GO111MODULE=on
-          export GOPROXY=https://proxy.golang.org
-          export GOSUMDB=sum.golang.org
-          go get k8s.io/test-infra/kubetest
+          # export GOPROXY=https://proxy.golang.org
+          # export GOSUMDB=sum.golang.org
+
+          git clone https://github.com/kubernetes/test-infra
+          cd test-infra
+          GOBIN='{{ k8s_src_dir }}' go install ./kubetest
+
           # Build all binaries
           export KUBE_FASTBUILD=true
           export KUBERNETES_CONFORMANCE_TEST=y
           # Go modules not supported by kubernetes before v1.15
-          if [ '{{ k8s_version }}' == 'release-1.13' ] || [ '{{ k8s_version }}' == 'release-1.14' ]; then
+          if [ '{{ k8s_version }}' == 'release-1.14' ]; then
             unset GO111MODULE
             unset GOSUMDB
             unset GOPROXY
@@ -135,7 +139,7 @@
           # Otherwise, kubetest will fail due to some unknow conflicts.
           # rm -rf _output/
 
-          kubetest --dump=$LOG_DIR \
+          ./kubetest --dump=$LOG_DIR \
               --test \
               --deployment=local \
               --provider=local \

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -569,7 +569,7 @@
     description: |
       Run Kubernetes E2E Conformance tests against Kubernetes master
     vars:
-      go_version: '1.12.1'
+      go_version: '1.12.4'
     run: playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
     post-run: playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/post.yaml
     nodeset: ubuntu-xenial-citynetwork


### PR DESCRIPTION
This PR fixes the conformance job failure, which is caused by unable to build kubetest