### PR TITLE
Bump go version to 1.12.10

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -560,6 +560,8 @@
     run: playbooks/cloud-provider-openstack-acceptance-test-k8s-cinder/run.yaml
     post-run: playbooks/cloud-provider-openstack-acceptance-test-k8s-cinder/post.yaml
     nodeset: ubuntu-xenial-citynetwork
+    vars:
+      go_version: '1.12.10'
     secrets:
       - citynetwork_credentials
 
@@ -699,6 +701,8 @@
     run: playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
     post-run: playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/post.yaml
     nodeset: ubuntu-xenial-citynetwork
+    vars:
+      go_version: '1.12.10'
     secrets:
       - citynetwork_credentials
 
@@ -748,6 +752,8 @@
       Run keystone auth acceptance tests of cloud-provider-openstack
     run: playbooks/cloud-provider-openstack-acceptance-test-keystone-authentication-authorization/run.yaml
     nodeset: ubuntu-xenial
+    vars:
+      go_version: '1.12.10'
 
 - job:
     name: cloud-provider-openstack-acceptance-test-flexvolume-cinder
@@ -756,6 +762,8 @@
       Run cinder flexvolume acceptance tests of cloud-provider-openstack
     run: playbooks/cloud-provider-openstack-acceptance-test-flexvolume-cinder/run.yaml
     nodeset: ubuntu-xenial
+    vars:
+      go_version: '1.12.10'
 
 - job:
     name: cluster-api-provider-openstack-image-build


### PR DESCRIPTION
This PR fixes the conformance job failure, which is caused by unable to build kubernetes:

```
make: Entering directory '/home/zuul/src/k8s.io/kubernetes'
make[1]: Entering directory '/home/zuul/src/k8s.io/kubernetes'

Detected go version: go version go1.12.1 linux/amd64.
Kubernetes requires go1.12.4 or greater.
Please install go1.12.4 or later.

!!! [1011 04:43:22] Call tree:
!!! [1011 04:43:22]  1: hack/run-in-gopath.sh:30 kube::golang::setup_env(...) 

Detected go version: go version go1.12.1 linux/amd64.
Kubernetes requires go1.12.4 or greater.
Please install go1.12.4 or later.
```

/cc @adisky @ramineni @huangtianhua 