### PR TITLE
Use v2.4.4 for spark testing

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -2024,10 +2024,10 @@
     name: spark-integration-test-minikube-k8s-v1.13.3
     parent: init-test
     description: |
-      Run integration tests of spark of v2.4.0 against v1.13.3 k8s cluster deployed by v0.34.1 minikube
+      Run integration tests of spark of v2.4.4 against v1.13.3 k8s cluster deployed by v0.34.1 minikube
     run: playbooks/spark-integration-test-minikube-k8s/run.yaml
     post-run: playbooks/spark-integration-test-minikube-k8s/post.yaml
-    override-checkout: v2.4.0
+    override-checkout: v2.4.4
     vars:
       k8s_log_dir: '{{ ansible_user_dir }}/workspace/logs/kubernetes'
       minikube_version: v0.34.1
@@ -2035,7 +2035,7 @@
     tags:
       - Category:BigData
       - Project:apache/spark
-      - Application:Spark@v2.4.0
+      - Application:Spark@v2.4.4
       - Application:Docker@19.03
       - Application:Kubernetes@v1.13.3
       - OS:ubuntu-xenial


### PR DESCRIPTION
Use v2.4.4 for spark testing because v2.4.4 is the latest released stable version.