### PR TITLE
flannel update in multinode to work with 1.16

### DIFF
--- a/roles/create-multinodes-k8s-cluster-with-kubeadm/tasks/main.yaml
+++ b/roles/create-multinodes-k8s-cluster-with-kubeadm/tasks/main.yaml
@@ -47,7 +47,7 @@
 
     # Installing a pod network add-on.
     # NOTE: when using calico adds-on, the pods in nodes can not access k8s services
-    kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/62e44c867a2846fefb68bd5f178daf4da3095ccb/Documentation/kube-flannel.yml
+    kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/023dc119c068d94590b2040d6550ff5ecfa190da/Documentation/kube-flannel.yml
 
     # make sure we can schedule pods on the master.
     kubectl taint nodes --all node-role.kubernetes.io/master-


### PR DESCRIPTION
Updated flannel to latest commit of the coreos repo. We need this update, because the
old one used deprecated resources that are removed in k8s 1.16.

With this change we still could test down to 1.10.