### PR TITLE
Bump etcd version for OpenStack k8s cloud provider

### DIFF
--- a/roles/install-k8s/defaults/main.yaml
+++ b/roles/install-k8s/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
 k8s_version: 'master'
-etcd_version: 'v3.3.17'
+etcd_version: 'v3.4.3'


### PR DESCRIPTION
/cc @adisky 
relates to https://github.com/kubernetes/cloud-provider-openstack/pull/762