### PR TITLE
CPO: export kubeconfig as env variable for e2e test

### DIFF
--- a/playbooks/cloud-provider-openstack-e2e-test-csi-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-e2e-test-csi-cinder/run.yaml
@@ -121,9 +121,10 @@
           fi
 
           export GO111MODULE=on
+          export KUBECONFIG=/var/run/kubernetes/admin.kubeconfig
           # Download kubectl binary
           curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x /usr/local/bin/kubectl
-          go test -v ./cmd/tests/cinder_csi_e2e_suite_test.go -ginkgo.v -ginkgo.progress -ginkgo.skip="\[Disruptive\]" -ginkgo.focus="\[cinder-csi-e2e\]" --kubeconfig=/var/run/kubernetes/admin.kubeconfig -timeout=0 -report-dir='{{ k8s_log_dir }}'
+              go test -v ./cmd/tests/cinder_csi_e2e_suite_test.go -ginkgo.v -ginkgo.progress -ginkgo.skip="\[Disruptive\]" -ginkgo.focus="\[cinder-csi-e2e\]" -timeout=0 -report-dir='{{ k8s_log_dir }}'
 
         executable: /bin/bash
         chdir: '{{ k8s_os_provider_src_dir }}'


### PR DESCRIPTION
This PR is to export kubeconfig as env variable which is required for e2e tests