### PR TITLE
CPO: Fix keystone job error

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-keystone-authentication-authorization/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-keystone-authentication-authorization/run.yaml
@@ -98,6 +98,8 @@
 
           K8S_INSTALL_SCRIPT='{{ k8s_src_dir }}/hack/local-up-cluster.sh'
           sed -i -e "/kube::util::wait_for_url.*$/,+1d" "$K8S_INSTALL_SCRIPT"
+          sed -i -e '/{GO_OUT}\/kube-apiserver\".*$/a \      --authorization-webhook-version=v1beta1 \\' "$K8S_INSTALL_SCRIPT"
+          sed -i -e '/{GO_OUT}\/kube-apiserver\".*$/a \      --authentication-token-webhook-version=v1beta1 \\' "$K8S_INSTALL_SCRIPT"
 
           # -E preserves the current env vars, but we need to special case PATH
           # Must run local-up-cluster.sh under kubernetes root directory


### PR DESCRIPTION
CPO keystone job is failing 
Root cause: kube-apiserver failed to start with error Error: invalid authorization config: unsupported webhook authorizer version "", supported versions are "v1", "v1beta1" . 
Explicitly pass the version while starting apiserver as per https://github.com/kubernetes/kubernetes/pull/84768