### PR TITLE
Add tpcds e2e test

### DIFF
--- a/playbooks/flink-end-to-end-test/e2e_tpcds.yaml
+++ b/playbooks/flink-end-to-end-test/e2e_tpcds.yaml
@@ -1,0 +1,49 @@
+- import_playbook: common.yaml
+
+- hosts: all
+  become: yes
+  tasks:
+    # Todo(wxy): Frocksdb doesn't have ARM release. Build and install it locally currently.
+    - name: Build and install frocksdb
+      shell:
+        cmd: |
+          git clone https://github.com/dataArtisans/frocksdb.git
+          cd frocksdb
+          git checkout origin/FRocksDB-5.17.2
+          sudo apt update
+          sudo apt install -y gcc g++ make
+          export DEBUG_LEVEL=0
+          make -j8 rocksdbjava
+
+          mvn install:install-file -DgroupId=com.data-artisans \
+          -DartifactId=frocksdbjni -Dversion=5.17.2-artisans-2.0 \
+          -Dpackaging=jar -Dfile=java/target/rocksdbjni-5.17.2-linux64.jar
+      args:
+        executable: /bin/bash
+        chdir: '/opt'
+      environment: '{{ global_env }}'
+
+    - name: Get the fix PR
+      shell:
+        cmd: |
+          git config --global user.email "info@openlabtesting.org"
+          git config --global user.name "OpenLab"
+          git remote add upstream http://github.com/apache/flink
+          git fetch upstream refs/pull/10424/head:pr_10424
+          git checkout pr_10424
+          git rebase master
+      args:
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
+      environment: '{{ global_env }}'
+
+    - name: Run split_tpcds.sh e2e test
+      shell:
+        cmd: |
+          set -xo pipefail
+          export PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3"
+          ./tools/travis/nightly.sh split_tpcds.sh
+      args:
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
+      environment: '{{ global_env }}'

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -2428,6 +2428,23 @@
     timeout: 54000
 
 - job:
+    name: flink-end-to-end-test-tpcds
+    parent: init-test
+    description: |
+      The flink e2e test which contains split_tpcds.sh
+    run: playbooks/flink-end-to-end-test/e2e_tpcds.yaml
+    post-run: playbooks/flink-end-to-end-test/post.yaml
+    nodeset: ubuntu-xenial-arm64-huaweicloud
+    tags:
+      - Category:BigData
+      - Project:apache/flink
+      - Application:Flink@master
+      - OS:ubuntu-xenial
+      - Arch:arm64
+      - BuildType:Integration test
+    timeout: 54000
+
+- job:
     name: flink-build-and-test-arm64-core-and-tests
     parent: init-test
     description: |

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -258,9 +258,11 @@
             branches: master
         - flink-end-to-end-test-misc-hadoopfree-and-misc:
             branches: master
+        - flink-end-to-end-test-container:
+            branches: master
     periodic-20:
       jobs:
-        - flink-end-to-end-test-container:
+        - flink-end-to-end-test-tpcds:
             branches: master
 
 # - project:


### PR DESCRIPTION
This patch add flink tpcds e2e test. And move the stable container
test to the mail queue.