### PR TITLE
Add new unit test for Flink

### DIFF
--- a/playbooks/flink-end-to-end-test/build_and_test_libraies_and_blink_planner.yaml
+++ b/playbooks/flink-end-to-end-test/build_and_test_libraies_and_blink_planner.yaml
@@ -1,0 +1,56 @@
+- import_playbook: common.yaml
+
+# NOTE: Some tests should not be ran under root.
+- hosts: all
+  become: yes
+  tasks:
+    # Todo(wxy): Frocksdb doesn't have ARM release. Build and install it locally currently.
+    - name: Build and install frocksdb
+      shell:
+        cmd: |
+          git clone https://github.com/dataArtisans/frocksdb.git
+          cd frocksdb
+          git checkout origin/FRocksDB-5.17.2
+          sudo apt update
+          sudo apt install -y gcc g++ make
+          export DEBUG_LEVEL=0
+          make -j8 rocksdbjava
+
+          mvn install:install-file -DgroupId=com.data-artisans \
+          -DartifactId=frocksdbjni -Dversion=5.17.2-artisans-2.0 \
+          -Dpackaging=jar -Dfile=java/target/rocksdbjni-5.17.2-linux64.jar
+      args:
+        executable: /bin/bash
+        chdir: '/opt'
+      environment: '{{ global_env }}'
+
+    - name: Build Flink libraies and blink_planner
+      shell:
+        cmd: |
+          set -xe
+          mvn clean install -nsu -Dflink.convergence.phase=install -Pcheck-convergence -Dflink.forkCount=2 \
+          -Dflink.forkCountTestPackage=2 -Dmaven.javadoc.skip=true -B -DskipTests -Dhadoop.version=2.8.3 \
+          -Dinclude_hadoop_aws -Dscala-2.11 -am -pl flink-libraries/flink-cep,flink-libraries/flink-cep-scala,\
+          flink-libraries/flink-state-processing-api,flink-table/flink-table-common,flink-table/flink-table-api-java,\
+          flink-table/flink-table-api-scala,flink-table/flink-table-api-java-bridge,flink-table/flink-table-api-scala-bridge,\
+          flink-table/flink-table-planner,flink-table/flink-sql-client,flink-table/flink-table-planner-blink,\
+          flink-table/flink-table-runtime-blink
+      args:
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
+      environment: '{{ global_env }}'
+
+    - name: Test Flink libraies and blink_planner
+      shell:
+        cmd: |
+          set -xe
+          mvn verify -nsu -Dflink.forkCount=2 -Dflink.forkCountTestPackage=2 -Dfast -B -Pskip-webui-build \
+          -Dflink.tests.force-openssl -Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11 -fn \
+          -pl flink-libraries/flink-cep,flink-libraries/flink-cep-scala,flink-libraries/flink-state-processing-api,\
+          flink-table/flink-table-common,flink-table/flink-table-api-java,flink-table/flink-table-api-scala,\
+          flink-table/flink-table-api-java-bridge,flink-table/flink-table-api-scala-bridge,flink-table/flink-table-planner,\
+          flink-table/flink-sql-client,flink-table/flink-table-planner-blink,flink-table/flink-table-runtime-blink
+      args:
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
+      environment: '{{ global_env }}'

--- a/playbooks/flink-end-to-end-test/build_and_test_misc.yaml
+++ b/playbooks/flink-end-to-end-test/build_and_test_misc.yaml
@@ -1,0 +1,80 @@
+- import_playbook: common.yaml
+
+# NOTE: Some tests should not be ran under root.
+- hosts: all
+  become: yes
+  tasks:
+    # Todo(wxy): Frocksdb doesn't have ARM release. Build and install it locally currently.
+    - name: Build and install frocksdb
+      shell:
+        cmd: |
+          git clone https://github.com/dataArtisans/frocksdb.git
+          cd frocksdb
+          git checkout origin/FRocksDB-5.17.2
+          sudo apt update
+          sudo apt install -y gcc g++ make
+          export DEBUG_LEVEL=0
+          make -j8 rocksdbjava
+
+          mvn install:install-file -DgroupId=com.data-artisans \
+          -DartifactId=frocksdbjni -Dversion=5.17.2-artisans-2.0 \
+          -Dpackaging=jar -Dfile=java/target/rocksdbjni-5.17.2-linux64.jar
+      args:
+        executable: /bin/bash
+        chdir: '/opt'
+      environment: '{{ global_env }}'
+
+    - name: Build Flink misc
+      shell:
+        cmd: |
+          set -xe
+
+          mvn clean install -nsu -Dflink.convergence.phase=install -Pcheck-convergence -Dflink.forkCount=2 \
+          -Dflink.forkCountTestPackage=2 -Dmaven.javadoc.skip=true -B -DskipTests -Dhadoop.version=2.8.3 \
+          -Dinclude_hadoop_aws -Dscala-2.11 install
+      args:
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
+      environment: '{{ global_env }}'
+
+    - name: Test Flink misc
+      shell:
+        cmd: |
+          set -xe
+          mvn verify -nsu -Dflink.forkCount=2 -Dflink.forkCountTestPackage=2 -Dfast -B -Pskip-webui-build \
+          -Dflink.tests.force-openssl -Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11 -fn \
+          -pl !flink-annotations,!flink-test-utils-parent/flink-test-utils,!flink-state-backends/flink-statebackend-rocksdb,\
+          !flink-clients,!flink-core,!flink-java,!flink-optimizer,!flink-runtime,!flink-runtime-web,!flink-scala,\
+          !flink-streaming-java,!flink-streaming-scala,!flink-metrics,!flink-metrics/flink-metrics-core,!flink-scala-shell,\
+          !flink-libraries/flink-cep,!flink-libraries/flink-cep-scala,!flink-libraries/flink-state-processing-api,\
+          !flink-table/flink-table-common,!flink-table/flink-table-api-java,!flink-table/flink-table-api-scala,\
+          !flink-table/flink-table-api-java-bridge,!flink-table/flink-table-api-scala-bridge,!flink-table/flink-table-planner,\
+          !flink-table/flink-sql-client,!flink-table/flink-table-planner-blink,!flink-table/flink-table-runtime-blink,\
+          !flink-contrib/flink-connector-wikiedits,!flink-filesystems,!flink-filesystems/flink-fs-hadoop-shaded,\
+          !flink-filesystems/flink-hadoop-fs,!flink-filesystems/flink-mapr-fs,!flink-filesystems/flink-oss-fs-hadoop,\
+          !flink-filesystems/flink-s3-fs-base,!flink-filesystems/flink-s3-fs-hadoop,!flink-filesystems/flink-s3-fs-presto,\
+          !flink-filesystems/flink-swift-fs-hadoop,!flink-fs-tests,!flink-formats,!flink-formats/flink-avro-confluent-registry,\
+          !flink-formats/flink-avro,!flink-formats/flink-parquet,!flink-formats/flink-sequence-file,!flink-formats/flink-json,\
+          !flink-formats/flink-csv,!flink-formats/flink-orc,!flink-connectors/flink-hbase,!flink-connectors/flink-hcatalog,\
+          !flink-connectors/flink-hadoop-compatibility,!flink-connectors/flink-jdbc,!flink-connectors,\
+          !flink-connectors/flink-connector-cassandra,!flink-connectors/flink-connector-elasticsearch2,\
+          !flink-connectors/flink-connector-elasticsearch5,!flink-connectors/flink-connector-elasticsearch6,\
+          !flink-connectors/flink-connector-elasticsearch7,!flink-connectors/flink-sql-connector-elasticsearch6,\
+          !flink-connectors/flink-sql-connector-elasticsearch7,!flink-connectors/flink-connector-elasticsearch-base,\
+          !flink-connectors/flink-connector-filesystem,!flink-connectors/flink-connector-kafka-0.9,\
+          !flink-connectors/flink-sql-connector-kafka-0.9,!flink-connectors/flink-connector-kafka-0.10,\
+          !flink-connectors/flink-sql-connector-kafka-0.10,!flink-connectors/flink-connector-kafka-0.11,\
+          !flink-connectors/flink-sql-connector-kafka-0.11,!flink-connectors/flink-connector-kafka-base,\
+          !flink-connectors/flink-connector-nifi,!flink-connectors/flink-connector-rabbitmq,\
+          !flink-connectors/flink-connector-twitter,!flink-connectors/flink-connector-kinesis,\
+          !flink-metrics/flink-metrics-dropwizard,!flink-metrics/flink-metrics-graphite,!flink-metrics/flink-metrics-jmx,\
+          !flink-metrics/flink-metrics-influxdb,!flink-metrics/flink-metrics-prometheus,!flink-metrics/flink-metrics-statsd,\
+          !flink-metrics/flink-metrics-datadog,!flink-metrics/flink-metrics-slf4j,\
+          !flink-queryable-state/flink-queryable-state-runtime,!flink-queryable-state/flink-queryable-state-client-java,\
+          !flink-connectors/flink-connector-kafka-0.8,!flink-libraries/flink-gelly,!flink-libraries/flink-gelly-scala,\
+          !flink-libraries/flink-gelly-examples,!flink-connectors/flink-connector-kafka,!flink-connectors/flink-sql-connector-kafka,\
+          !,!flink-tests
+      args:
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
+      environment: '{{ global_env }}'

--- a/playbooks/flink-end-to-end-test/e2e_tpcds.yaml
+++ b/playbooks/flink-end-to-end-test/e2e_tpcds.yaml
@@ -23,20 +23,6 @@
         chdir: '/opt'
       environment: '{{ global_env }}'
 
-    - name: Get the fix PR
-      shell:
-        cmd: |
-          git config --global user.email "info@openlabtesting.org"
-          git config --global user.name "OpenLab"
-          git remote add upstream http://github.com/apache/flink
-          git fetch upstream refs/pull/10424/head:pr_10424
-          git checkout pr_10424
-          git rebase master
-      args:
-        executable: /bin/bash
-        chdir: '{{ zuul.project.src_dir }}'
-      environment: '{{ global_env }}'
-
     - name: Comment out docker installation
       lineinfile:
         path: "/home/zuul/src/github.com/apache/flink/tools/travis/nightly.sh"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -2360,7 +2360,7 @@
     timeout: 54000
 
 - job:
-    name: flink-end-to-end-test-checkpoints-and-sticky
+    name: flink-end-to-end-test-arm64-checkpoints-and-sticky
     parent: init-test
     description: |
       The flink e2e test which contains split_checkpoints.sh, split_sticky.sh
@@ -2377,7 +2377,7 @@
     timeout: 54000
 
 - job:
-    name: flink-end-to-end-test-heavy-and-ha
+    name: flink-end-to-end-test-arm64-heavy-and-ha
     parent: init-test
     description: |
       The flink e2e test which contains split_heavy.sh, split_ha.sh
@@ -2394,7 +2394,7 @@
     timeout: 54000
 
 - job:
-    name: flink-end-to-end-test-misc-hadoopfree-and-misc
+    name: flink-end-to-end-test-arm64-misc-hadoopfree-and-misc
     parent: init-test
     description: |
       The flink e2e test which contains split_misc.sh, split_misc_hadoopfree.sh
@@ -2411,7 +2411,7 @@
     timeout: 54000
 
 - job:
-    name: flink-end-to-end-test-container
+    name: flink-end-to-end-test-arm64-container
     parent: init-test
     description: |
       The flink e2e test which contains split_container.sh
@@ -2428,7 +2428,7 @@
     timeout: 54000
 
 - job:
-    name: flink-end-to-end-test-tpcds
+    name: flink-end-to-end-test-arm64-tpcds
     parent: init-test
     description: |
       The flink e2e test which contains split_tpcds.sh
@@ -2450,6 +2450,38 @@
     description: |
       The flink-core build and test on ARM for core and tests component.
     run: playbooks/flink-end-to-end-test/build_and_test_core_and_tests.yaml
+    nodeset: ubuntu-xenial-arm64-huaweicloud
+    tags:
+      - Category:BigData
+      - Project:apache/flink
+      - Application:Flink@master
+      - OS:ubuntu-xenial
+      - Arch:arm64
+      - BuildType:Unit test
+    timeout: 54000
+
+- job:
+    name: flink-build-and-test-arm64-libraies-and-blink_planner
+    parent: init-test
+    description: |
+      The flink-core build and test on ARM for libraies and blink_planner component.
+    run: playbooks/flink-end-to-end-test/build_and_test_libraies_and_blink_planner.yaml
+    nodeset: ubuntu-xenial-arm64-huaweicloud
+    tags:
+      - Category:BigData
+      - Project:apache/flink
+      - Application:Flink@master
+      - OS:ubuntu-xenial
+      - Arch:arm64
+      - BuildType:Unit test
+    timeout: 54000
+
+- job:
+    name: flink-build-and-test-arm64-misc
+    parent: init-test
+    description: |
+      The flink-core build and test on ARM for misc component.
+    run: playbooks/flink-end-to-end-test/build_and_test_misc.yaml
     nodeset: ubuntu-xenial-arm64-huaweicloud
     tags:
       - Category:BigData

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -252,17 +252,21 @@
       jobs:
         - flink-build-and-test-arm64-core-and-tests:
             branches: master
-        - flink-end-to-end-test-checkpoints-and-sticky:
+        - flink-end-to-end-test-arm64-checkpoints-and-sticky:
             branches: master
-        - flink-end-to-end-test-heavy-and-ha:
+        - flink-end-to-end-test-arm64-heavy-and-ha:
             branches: master
-        - flink-end-to-end-test-misc-hadoopfree-and-misc:
+        - flink-end-to-end-test-arm64-misc-hadoopfree-and-misc:
             branches: master
-        - flink-end-to-end-test-container:
+        - flink-end-to-end-test-arm64-container:
+            branches: master
+        - flink-end-to-end-test-arm64-tpcds:
             branches: master
     periodic-20:
       jobs:
-        - flink-end-to-end-test-tpcds:
+        - flink-build-and-test-arm64-libraies-and-blink_planner:
+            branches: master
+        - flink-build-and-test-arm64-misc:
             branches: master
 
 # - project:


### PR DESCRIPTION
This PR did:
1. Move tpcds test to offical
2. Add a new job for libraries and blink-planner
3. Add a new job for misc
4. Remove the hack in tpcds test which is merged into Flink Upstream already.