### PR TITLE
CPO: Add release-1.17 conformance job

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -709,6 +709,28 @@
       - BuildType:Integration test
 
 - job:
+    name: cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.17
+    parent: cloud-provider-openstack-acceptance-test-e2e-conformance
+    description: |
+      Run Kubernetes E2E Conformance tests against release-1.17 branch of Kubernetes
+    nodeset: ubuntu-xenial-citynetwork
+    vars:
+      go_version: '1.13.4'
+      k8s_version: 'release-1.17'
+      etcd_version: 'v3.4.3'
+    tags:
+      - Category:Cloud
+      - Project:kubernetes/cloud-provider-openstack
+      - Application:cloud-provider-openstack@release-1.17
+      - Application:Kubernetes@release-1.17
+      - Application:Docker.io@v18.09
+      - Application:Etcd@v3.4.3
+      - Application:Go@1.13.4
+      - OS:ubuntu-xenial
+      - Arch:x86_64
+      - BuildType:Integration test
+
+- job:
     name: cloud-provider-openstack-acceptance-test-standalone-cinder
     parent: cloud-provider-openstack-test
     description: |

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -103,12 +103,12 @@
       jobs:
         - cloud-provider-openstack-acceptance-test-e2e-conformance:
             branches: master
+        - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.17:
+            branches: release-1.17
         - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.16:
             branches: release-1.16
         - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.15:
             branches: release-1.15
-        - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.14:
-            branches: release-1.14
         - cloud-provider-openstack-multinode-csi-migration-test:
             branches: master
 


### PR DESCRIPTION
This commit adds cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.17 job