### PR TITLE
Updated CSIMigration playbook to fix bootstrap

### DIFF
--- a/playbooks/cloud-provider-openstack-multinode-csi-migration-test/pre.yaml
+++ b/playbooks/cloud-provider-openstack-multinode-csi-migration-test/pre.yaml
@@ -43,7 +43,7 @@
         - master
   tasks:
     - name: get kubeadm join command
-      shell: kubeadm token create --print-join-command
+      shell: kubeadm token create --print-join-command 2>/dev/null
       register: kubeadm_join_cmd
 
 - hosts: k8s-node-1,k8s-node-2

--- a/playbooks/cloud-provider-openstack-multinode-csi-migration-test/run.yaml
+++ b/playbooks/cloud-provider-openstack-multinode-csi-migration-test/run.yaml
@@ -8,6 +8,8 @@
         cmd: |
           set -o pipefail
           set -e
+          log_dir={{ k8s_log_dir }}
+          mkdir -p "$log_dir"
           excludes=(
             "\[Disruptive\]"
             "\[sig-storage\]\sIn-tree\sVolumes\s\[Driver:\scinder\]\s\[Testpattern:\sPre-provisioned\sPV\s\(block\svolmode\)\]\svolumeMode\sshould\sfail\sto\screate\spod\sby\sfailing\sto\smount\svolume\s\[Slow\]"
@@ -18,8 +20,10 @@
           /root/kubernetes/test/bin/e2e.test \
             -kubeconfig=/etc/kubernetes/admin.conf \
             -provider=openstack \
+            -storage.migratedPlugins=cinder \
+            -report-dir="$log_dir" \
             -ginkgo.noColor \
             -ginkgo.focus="[V|v]olume\sexpand|\[sig-storage\]\sIn-tree\sVolumes\s\[Driver:\scinder\]|allowedTopologies|Pod\sDisks|PersistentVolumes\sDefault" \
-            -ginkgo.skip="$exclude_regex" | tee /root/csi-migration.log
+            -ginkgo.skip="$exclude_regex" | tee "$log_dir/e2e.log"
       args:
         executable: /bin/bash


### PR DESCRIPTION
Fixed bootstrap for of k8s-nodes. Somehow the ansible run captured
stderr and stdout combined, what caused a failure when bootstrappping
nodes.

Enabled junit output.