### PR TITLE
CPO: Fix migration test

### DIFF
--- a/playbooks/cloud-provider-openstack-multinode-csi-migration-test/pre.yaml
+++ b/playbooks/cloud-provider-openstack-multinode-csi-migration-test/pre.yaml
@@ -57,6 +57,8 @@
 
 - hosts: k8s-master
   name: prepare testcases, install necessary components
+  roles:
+    - config-golang
   become: yes
   tasks:
     - name: install python-cinderclient
@@ -141,7 +143,7 @@
             echo "Failed to install container registry"
             exit 1
           fi
-          ./hack/make.sh cinder-csi-plugin
+          make cinder-csi-plugin
           cp cinder-csi-plugin cluster/images/cinder-csi-plugin
           docker build -t localhost:32000/k8scloudprovider/cinder-csi-plugin:latest cluster/images/cinder-csi-plugin
 

--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -931,6 +931,43 @@
       mysql:
 
 - pipeline:
+    name: cloud-provider-openstack-multinode-csi-migration-test
+    description: |
+      Commenting "/test cloud-provider-openstack-multinode-csi-migration-test" enter this pipeline to run
+      the tests job of Kubernetes+OpenStack CSI migration scenarios and receive an initial
+      +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action:
+            - opened
+            - changed
+            - reopened
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test cloud-provider-openstack-multinode-csi-migration-test\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/retest\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test all\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+        status-url: https://status.openlabtesting.org/status/change/{change.number},{change.patchset}
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
     name: cloud-provider-openstack-acceptance-test-flexvolume-cinder
     description: |
       Commenting "/test cloud-provider-openstack-acceptance-test-flexvolume-cinder" enter this pipeline to run


### PR DESCRIPTION
This commit updates migration test to install go on k8s master node
and run make on csi cinderplugin. This commit also adds the pipeline
to run the job when PR submitted.