### PR TITLE
CPO: update the pipeline for CPO jobs

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/post.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/post.yaml
@@ -20,7 +20,7 @@
           # TODO(RuiChen): Add timestamp for e2e.log in order to workaround upload_e2e.py bug
           date  +"%b %e %H:%M:%S.999: DONE" >> $LOG_DIR/e2e.log
           PIPELINE_LOGS_DIR='periodic-logs'
-          if [ '{{ zuul.pipeline }}' != 'periodic-4/16' ]; then
+          if [ '{{ zuul.pipeline }}' != 'periodic-14' ]; then
               PIPELINE_LOGS_DIR='pr-logs'
           fi
           # upload e2e log to google storage

--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -157,7 +157,7 @@
     - name: Run image build and publish for cloud-provider-openstack
       shell:
         cmd: |
-          if [ '{{ zuul.pipeline }}' == 'periodic-4/16' ] && [ '{{ zuul.branch }}' == 'master' ]; then
+          if [ '{{ zuul.pipeline }}' == 'periodic-14' ] && [ '{{ zuul.branch }}' == 'master' ]; then
             set -ex
             set -o pipefail
 

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -697,7 +697,7 @@
       Run Kubernetes E2E Conformance tests against release-1.16 branch of Kubernetes
     nodeset: ubuntu-xenial-citynetwork
     vars:
-      go_version: '1.12.4'
+      go_version: '1.13.5'
       k8s_version: 'release-1.16'
       etcd_version: 'v3.3.15'
     tags:
@@ -707,7 +707,7 @@
       - Application:Kubernetes@release-1.16
       - Application:Docker.io@v18.09
       - Application:Etcd@v3.3.15
-      - Application:Go@1.12.4
+      - Application:Go@1.13.5
       - OS:ubuntu-xenial
       - Arch:x86_64
       - BuildType:Integration test


### PR DESCRIPTION
Pipeline for CPO jobs seems to be changed, so latest images are
not getting pushed to docker registry. This commit updates the
pipeline in CPO jobs as well to fix the same.
This commit also fixes the periodic job failure of 
cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.16
by updating go version to 1.13.5 .