### PR TITLE
CPO: docker push using node ip

### DIFF
--- a/playbooks/cloud-provider-openstack-multinode-csi-migration-test/pre.yaml
+++ b/playbooks/cloud-provider-openstack-multinode-csi-migration-test/pre.yaml
@@ -132,6 +132,8 @@
         cmd: |
           set -o pipefail
           set -ex
+          mkdir -p '{{ k8s_log_dir }}'
+          export LOG_DIR='{{ k8s_log_dir }}'
 
           if ! timeout 300 bash -c '
             while :
@@ -143,12 +145,26 @@
             echo "Failed to install container registry"
             exit 1
           fi
+          kubectl describe pods -l app=registry > "$LOG_DIR/registry-pods.txt"
+          # Get the node IP
+          node_ip = $(kubectl get pods -l app=registry -o custom-columns=:.status.hostIP --no-headers)
+          echo $node_ip
           make cinder-csi-plugin
           cp cinder-csi-plugin cluster/images/cinder-csi-plugin
-          docker build -t localhost:32000/k8scloudprovider/cinder-csi-plugin:latest cluster/images/cinder-csi-plugin
+          docker build -t $node_ip:32000/k8scloudprovider/cinder-csi-plugin:latest cluster/images/cinder-csi-plugin
+
+    - name: clean up iptable rules
+      shell:
+        cmd: |
+          iptables -F
+          iptables -P FORWARD ACCEPT
 
     - name: push cluster-local-build of cinder-csi-plugin to local registry
-      command: docker push localhost:32000/k8scloudprovider/cinder-csi-plugin:latest
+      shell:
+        cmd: |
+          node_ip = $(kubectl get pods -l app=registry -o custom-columns=:.status.hostIP --no-headers)
+          echo $node_ip
+          docker push $node_ip:32000/k8scloudprovider/cinder-csi-plugin:latest
       retries: 5
       delay: 5
 


### PR DESCRIPTION
migration job unable to push the images to registry
 2020-01-21 05:05:15.520655 | TASK [push cluster-local-build of cinder-csi-plugin to local registry]
2020-01-21 04:05:16.167565 | k8s-master | The push refers to repository [localhost:32000/k8scloudprovider/cinder-csi-plugin]
2020-01-21 04:05:46.172091 | k8s-master | Get http://localhost:32000/v2/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)

This PR tries to push using node ip and also clears the iptables before the docker push to resolve the error