### PR TITLE
Remove distutils httplib2 for devstack

### DIFF
--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -79,6 +79,9 @@
 
       # Delete all rules in chain openstack-INPUT to allow unlimited access from nested vm
       iptables -F openstack-INPUT || true
+
+      # Remove distutils packages that conflict with pip packages that devstack needs to bigip_software_install
+      apt remove python3-httplib2
     executable: /bin/bash
     chdir: '{{ ansible_user_dir }}/workspace'
   environment: '{{ zuul | zuul_legacy_vars }}'


### PR DESCRIPTION
It conflicts with devstack's pip install of httplib2.

Closes: https://github.com/theopenlab/openlab/issues/452