### PR TITLE
install-devstack: Removed python3-httplib2 with apt module

### DIFF
--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -79,12 +79,14 @@
 
       # Delete all rules in chain openstack-INPUT to allow unlimited access from nested vm
       iptables -F openstack-INPUT || true
-
-      # Remove distutils packages that conflict with pip packages that devstack needs to bigip_software_install
-      apt remove python3-httplib2
     executable: /bin/bash
     chdir: '{{ ansible_user_dir }}/workspace'
   environment: '{{ zuul | zuul_legacy_vars }}'
+
+- name: Remove distutils packages that conflict with pip packages that devstack needs to install
+  apt:
+    name: python3-httplib2
+    state: absent
 
 # Convert multiple key=value pairs to json format
 #   's/^/"/' - add " at the beginning of each line


### PR DESCRIPTION
Currently apt waits for user input to remove `python3-httplib2`. This PR uses the apt module to uninstall the package.

Relates to: #785 

https://logs.openlabtesting.org/logs/19/919/8c9146151bd70313453c38328cc51dd64af61c0c/cloud-provider-openstack-acceptance-test-flexvolume-cinder/cloud-provider-openstack-acceptance-test-flexvolume-cinder/aae2d4a/job-output.txt.gz

```
2020-01-30 04:16:14.732684 | ubuntu-bionic | The following packages will be REMOVED:
2020-01-30 04:16:14.734138 | ubuntu-bionic |   apport python3-apport python3-httplib2 ubuntu-server
2020-01-30 04:16:14.742028 | ubuntu-bionic | 0 upgraded, 0 newly installed, 4 to remove and 3 not upgraded.
2020-01-30 04:16:14.742122 | ubuntu-bionic | After this operation, 1533 kB disk space will be freed.
2020-01-30 04:16:14.742209 | ubuntu-bionic | Do you want to continue? [Y/n] Abort.```