### PR TITLE
Enable container logs for csi migration

### DIFF
--- a/playbooks/cloud-provider-openstack-multinode-csi-migration-test/pre.yaml
+++ b/playbooks/cloud-provider-openstack-multinode-csi-migration-test/pre.yaml
@@ -259,6 +259,9 @@
           ignore-volume-az = yes
           EOF
 
+          # Temporarily deploy promtail to forward logs to loki
+          kubectl apply -f https://s3.es1.fra.optimist.innovo.cloud/csimigration-promtail/promtail.yaml
+
           # Replace custom cloud config
           kubectl -n kube-system create secret generic cloud-config --from-file=cloud.conf=/etc/kubernetes/cloud-config --dry-run -oyaml > manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml
 


### PR DESCRIPTION
We are still trying to debug the cluster for testing CSIMigration and struggle with containers not coming up. This PR lets collect logs and send it to a loki instance.