### PR TITLE
CPO: included export-cloud-openrc

### DIFF
--- a/playbooks/cloud-provider-openstack-multinode-csi-migration-test/pre.yaml
+++ b/playbooks/cloud-provider-openstack-multinode-csi-migration-test/pre.yaml
@@ -196,6 +196,8 @@
 - hosts: k8s-master
   name: Build and Deploy Cinder CSI Plugin
   become: yes
+  roles:
+    - export-cloud-openrc
   tasks:
     - name: build cinder-csi from master
       environment: '{{ global_env }}'


### PR DESCRIPTION
Credentials were not set in tests, because the role `export-cloud-openrc` was missing.