### PR TITLE
CPO: Export cloud openrc in run.yaml

### DIFF
--- a/playbooks/cloud-provider-openstack-multinode-csi-migration-test/run.yaml
+++ b/playbooks/cloud-provider-openstack-multinode-csi-migration-test/run.yaml
@@ -1,6 +1,8 @@
 - hosts: k8s-master
   name: Run Kubernetes e2e.test for sig-storage and the cinder driver
   become: yes
+  roles:
+    - export-cloud-openrc
   tasks:
     - name: Run test
       environment: "{{ global_env }}"


### PR DESCRIPTION
This PR includes the role export-cloud-openrc in run.yaml as the credentials needed while running tests as well.