### PR TITLE
Loadbalancer type of Service test for OCCM

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/post.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/post.yaml
@@ -1,24 +1,31 @@
 - hosts: all
   become: yes
   roles:
-    - export-cloud-openrc
+    - role: export-cloud-openrc
+      vars:
+        cloud_name: "catalyst"
   tasks:
-    - name: Clean up resources for lbass octavia acceptance tests
+    - name: Clean up k8s services
       shell:
-        cmd: |
-          set -e
-          set -x
-          '{{ kubectl }}' config use-context local
-          ext_lb_svc_uid=$('{{ kubectl }}' get services external-http-nginx-service -o=jsonpath='{.metadata.uid}') || true
-          int_lb_svc_uid=$('{{ kubectl }}' get services internal-http-nginx-service -o=jsonpath='{.metadata.uid}') || true
-
-          '{{ kubectl }}' delete -f examples/loadbalancers/internal-http-nginx.yaml || true
-          '{{ kubectl }}' delete -f examples/loadbalancers/external-http-nginx.yaml || true
-
-          for lb_svc_uid in $ext_lb_svc_uid $int_lb_svc_uid; do
-              lb_name=$(echo $lb_svc_uid | tr -d '-' | sed 's/^/a/' | cut -c -32)
-              openstack loadbalancer delete --cascade $lb_name || true
-          done
         executable: /bin/bash
-        chdir: '{{ k8s_os_provider_src_dir }}'
+        cmd: |
+          set -o pipefail
+          services=$(kubectl -n octavia-lb-test get svc -o json | jq -r '.items[] | .metadata.name')
+          for i in $services; do kubectl -n octavia-lb-test delete svc $i; done
+          # Sleep 10s to make sure occm finishes deleting all the cloud resources.
+          sleep 10
+
+    - name: Clean up load balancers
+      shell: |
+        # Delete all the existing load balancers
+        lbs=$(openstack loadbalancer list -c id -f value)
+        for i in $lbs; do openstack loadbalancer delete --cascade $i; done
       environment: '{{ global_env }}'
+
+    - name: Remove PR label for openstack-cloud-controller-manager
+      shell: kubectl -n kube-system label ds openstack-cloud-controller-manager PR-
+      ignore_errors: True
+
+    - name: Remove openstack-cloud-controller-manager image from docker hub
+      shell: docker run --rm lumir/remove-dockerhub-tag --user {{ dockerhub.username }} --password {{ dockerhub.password }} {{ dockerhub.username }}/openstack-cloud-controller-manager:{{ zuul.change }}
+      no_log: yes

--- a/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
@@ -1,124 +1,141 @@
 - hosts: all
   become: yes
   roles:
-    - config-golang
-    - export-cloud-openrc
-    - install-k8s
+    - config-docker-machine
+    - role: export-cloud-openrc
+      vars:
+        cloud_name: "catalyst"
   tasks:
-    - name: Run lbass octavia acceptance tests with cloud-provider-openstack
+    - name: Login dockerhub
+      shell: docker login -u {{ dockerhub.username }} -p {{ dockerhub.password }}
+      no_log: yes
+
+    - name: Install kubectl and jq
       shell:
         cmd: |
-          set -x
-          set -e
+          curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+          chmod +x ./kubectl
+          mv ./kubectl /usr/local/bin/kubectl
+          mkdir ~/.kube
+          cat << EOF >> ~/.kube/config
+          {{ kubeconfig.content }}
+          EOF
+          apt install -y jq
+      no_log: yes
+
+    - name: Build openstack-cloud-controller-manager image
+      shell:
+        cmd: make image-controller-manager REGISTRY={{ dockerhub.username }} VERSION={{ zuul.change }}
+        chdir: '{{ k8s_os_provider_src_dir }}'
+
+    - name: Upload openstack-cloud-controller-manager image
+      shell: docker push {{ dockerhub.username }}/openstack-cloud-controller-manager:{{ zuul.change }}
+
+    - name: Wait until openstack-cloud-controller-manager is avaialble for patching
+      shell:
+        executable: /bin/bash
+        cmd: |
           set -o pipefail
+          kubectl -n kube-system get ds openstack-cloud-controller-manager -o json | jq -r '.metadata.labels | keys | .[]'
+      register: result
+      until: '"PR" not in result.stdout_lines'
+      retries: 30
+      delay: 10
 
-          # Build cloud-provider-openstack binaries
-          make build
-
-          apt-get install python-pip -y
-          pip install -U python-openstackclient python-octaviaclient python-neutronclient
-
-          # Create cloud-config
-          mkdir -p /etc/kubernetes/
-          cat << EOF >> /etc/kubernetes/cloud-config
-          [Global]
-          domain-name = $OS_USER_DOMAIN_NAME
-          tenant-id = $OS_PROJECT_ID
-          auth-url = $OS_AUTH_URL
-          password = $OS_PASSWORD
-          username = $OS_USERNAME
-          region = $OS_REGION_NAME
-          [LoadBalancer]
-          use-octavia = true
-          floating-network-id = $(openstack network list --external -f value -c ID | head -n 1)
-          subnet-id = $(openstack network list --internal -f value -c Subnets | head -n 1 | cut -d "," -f1)
-          [BlockStorage]
-          bs-version = v3
-          ignore-volume-az = yes
+    - name: Update openstack-cloud-controller-manager with the new docker image
+      shell:
+        executable: /bin/bash
+        cmd: |
+          set -o pipefail
+          cat <<EOF | kubectl apply -f -
+          apiVersion: extensions/v1beta1
+          kind: DaemonSet
+          metadata:
+            labels:
+              k8s-app: openstack-cloud-controller-manager
+              PR: {{ zuul.change }}
+            name: openstack-cloud-controller-manager
+            namespace: kube-system
+          spec:
+            selector:
+              matchLabels:
+                k8s-app: openstack-cloud-controller-manager
+            template:
+              metadata:
+                labels:
+                  k8s-app: openstack-cloud-controller-manager
+              spec:
+                containers:
+                - command:
+                  - /bin/openstack-cloud-controller-manager
+                  - --v=2
+                  - --cloud-config=/etc/kubernetes/cloud-config
+                  - --cluster-name=ccacfedb-c04e-44f4-9420-262f64628d6f
+                  - --use-service-account-credentials=true
+                  - --bind-address=127.0.0.1
+                  image: {{ dockerhub.username }}/openstack-cloud-controller-manager:{{ zuul.change }}
+                  imagePullPolicy: Always
+                  name: openstack-cloud-controller-manager
+                  volumeMounts:
+                  - mountPath: /etc/kubernetes
+                    name: cloudconfig
+                    readOnly: true
+                hostNetwork: true
+                nodeSelector:
+                  node-role.kubernetes.io/master: ""
+                restartPolicy: Always
+                serviceAccount: cloud-controller-manager
+                serviceAccountName: cloud-controller-manager
+                tolerations:
+                - effect: NoSchedule
+                  key: node.cloudprovider.kubernetes.io/uninitialized
+                  value: "true"
+                - effect: NoSchedule
+                  key: dedicated
+                  value: master
+                - effect: NoSchedule
+                  key: CriticalAddonsOnly
+                  value: "True"
+                volumes:
+                - hostPath:
+                    path: /etc/kubernetes
+                    type: ""
+                  name: cloudconfig
           EOF
 
-          export API_HOST_IP=$(ip route get 1.1.1.1 | awk '{print $7}')
-          export KUBELET_HOST="0.0.0.0"
-          export ALLOW_SECURITY_CONTEXT=true
-          export ENABLE_CRI=false
-          export ENABLE_HOSTPATH_PROVISIONER=true
-          export ENABLE_SINGLE_CA_SIGNER=true
-          export KUBE_ENABLE_CLUSTER_DNS=false
-          export LOG_LEVEL=4
-          # We want to use the openstack cloud provider
-          export CLOUD_PROVIDER=openstack
-          # We want to run a separate cloud-controller-manager for openstack
-          export EXTERNAL_CLOUD_PROVIDER=true
-          # DO NOT change the location of the cloud-config file. It is important for the old cinder provider to work
-          export CLOUD_CONFIG=/etc/kubernetes/cloud-config
-          # Specify the OCCM binary
-          export EXTERNAL_CLOUD_PROVIDER_BINARY="$PWD/openstack-cloud-controller-manager"
+    - name: Wait for openstack-cloud-controller-manager up and running
+      shell:
+        executable: /bin/bash
+        cmd: |
+          set -o pipefail
+          kubectl -n kube-system get po | grep openstack-cloud-controller-manager | grep Running
+      register: check_pod
+      until: check_pod.rc == 0
+      retries: 24
+      delay: 5
 
-          # location of where the kubernetes processes log their output
-          mkdir -p '{{ k8s_log_dir }}'
-          export LOG_DIR='{{ k8s_log_dir }}'
-          # We need this for one of the conformance tests
-          export ALLOW_PRIVILEGED=true
-          # Just kick off all the processes and drop down to the command line
-          export ENABLE_DAEMON=true
-          if [ -d /mnt/config/openstack ]; then
-              export HOSTNAME_OVERRIDE=$(hostname)
+    # This is specially designed for Catalyst Cloud as creating floating IP with description is not supported yet.
+    - name: Find an available floating IP
+      shell:
+        executable: /bin/bash
+        cmd: |
+          set -e
+          set -o pipefail
+          ret=$(openstack floating ip list -f value -c "Fixed IP Address" -c "Floating IP Address" | grep None | awk 'NR==1 {print}')
+          if [[ -z $ret ]]; then
+              public_net=$(openstack network list --external -f value -c Name)
+              fip=$(openstack floating ip create ${public_net} -c floating_ip_address -f value)
           else
-              export HOSTNAME_OVERRIDE=$(curl http://169.254.169.254/openstack/latest/meta_data.json | python -c "import sys, json; print json.load(sys.stdin)['name']")
+              fip=${ret% *}
           fi
-          export MAX_TIME_FOR_URL_API_SERVER=5
+          echo $fip
+      register: floating_ip
+      environment: '{{ global_env }}'
 
-          # -E preserves the current env vars, but we need to special case PATH
-          # Must run local-up-cluster.sh under kubernetes root directory
-          pushd '{{ k8s_src_dir }}'
-          sudo -E PATH=$PATH SHELLOPTS=$SHELLOPTS ./hack/local-up-cluster.sh -O
-          popd
-
-          # set up the config we need for kubectl to work
-          '{{ kubectl }}' config set-cluster local --server=https://localhost:6443 --certificate-authority=/var/run/kubernetes/server-ca.crt
-          '{{ kubectl }}' config set-credentials myself --client-key=/var/run/kubernetes/client-admin.key --client-certificate=/var/run/kubernetes/client-admin.crt
-          '{{ kubectl }}' config set-context local --cluster=local --user=myself
-          '{{ kubectl }}' config use-context local
-          # Hack for RBAC for all for the new cloud-controller process, we need to do better than this
-          '{{ kubectl }}' create clusterrolebinding --user system:serviceaccount:kube-system:default kube-system-cluster-admin-1 --clusterrole cluster-admin
-          '{{ kubectl }}' create clusterrolebinding --user system:serviceaccount:kube-system:pvl-controller kube-system-cluster-admin-2 --clusterrole cluster-admin
-          '{{ kubectl }}' create clusterrolebinding --user system:serviceaccount:kube-system:cloud-node-controller kube-system-cluster-admin-3 --clusterrole cluster-admin
-          '{{ kubectl }}' create clusterrolebinding --user system:serviceaccount:kube-system:cloud-controller-manager kube-system-cluster-admin-4 --clusterrole cluster-admin
-          '{{ kubectl }}' create clusterrolebinding --user system:serviceaccount:kube-system:shared-informers kube-system-cluster-admin-5 --clusterrole cluster-admin
-          '{{ kubectl }}' create clusterrolebinding --user system:kube-controller-manager  kube-system-cluster-admin-6 --clusterrole cluster-admin
-
-          # Run test
-          for test_case in internal external
-          do
-            test_file="examples/loadbalancers/${test_case}-http-nginx.yaml"
-            service_name="${test_case}-http-nginx-service"
-            # Delete fake floating-network-id to use the default one in cloud config
-            sed -i '/loadbalancer.openstack.org/d' "$test_file"
-            '{{ kubectl }}' create -f "$test_file"
-
-            if ! service_name="$service_name" timeout 600 bash -c '
-                while :
-                do
-                    [[ -n $({{ kubectl }} describe service "$service_name" | awk "/LoadBalancer Ingress/ {print \$3}") ]] && break
-                    sleep 1
-                done
-                '
-            then
-                echo "Timed out to wait for $test_case loadbalancer services deployment!"
-                '{{ kubectl }}' describe pods
-                '{{ kubectl }}' describe services
-                exit 1
-            fi
-
-            ingress_ip=$('{{ kubectl }}' describe service "$service_name" | awk "/LoadBalancer Ingress/ {print \$3}")
-            if curl --retry 5 --retry-max-time 30 "http://$ingress_ip" | grep 'Welcome to nginx'
-            then
-                echo "$test_case lb services launched sucessfully!"
-            else
-                echo "$test_case lb services launched failed!"
-                exit 1
-            fi
-          done
+    - name: Run acceptance tests for LoadBalancer Service
+      shell:
         executable: /bin/bash
         chdir: '{{ k8s_os_provider_src_dir }}'
+        cmd: |
+          FLOATING_IP={{ floating_ip.stdout }} CLUSTERNAME=c886a618-c92a-4d4d-9f8f-bd2201f4dafd bash tools/test-lb-service.sh
       environment: '{{ global_env }}'

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -650,7 +650,7 @@
       - OS:ubuntu-xenial
       - Arch:x86_64
       - BuildType:Integration test
-      
+
 - job:
     name: cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.15
     parent: cloud-provider-openstack-acceptance-test-e2e-conformance
@@ -821,6 +821,7 @@
     nodeset: ubuntu-xenial-vexxhost-lb
     secrets:
       - vexxhost_credentials
+      - kubeconfig
 
 - job:
     name: cloud-provider-openstack-acceptance-test-keystone-authentication-authorization
@@ -2194,7 +2195,7 @@
       run_kubeflow_tfbenchmarks: true
       run_volcano_tfbenchmarks: true
     nodeset: ubuntu-xenial-k8s-tf
-    
+
 # grandson job for stein
 - job:
     name: rust-openstack-0.2.3-acceptance-stein
@@ -2210,7 +2211,7 @@
       - OS:ubuntu-xenial
       - Arch:x86_64
       - BuildType:Integration test
-    
+
 # grandson job for rocky
 - job:
     name: rust-openstack-0.2.3-acceptance-rocky


### PR DESCRIPTION
Basically, the workflow is:
- A new PR related to OCCM code is submitted.
- Openlab launches a VM and runs this zuul job.
- The OCCM image is built inside the VM and uploaded to docker hub.
- The zuul job updates image for OCCM running in an existing k8s
  cluster on Catalyst Cloud.
- Zuul job executes a shell script as functional testing.

What are needed:
- An openrc file for Catalyst Cloud.
- The kubeconfig file for the existing k8s cluster.
- Put test-lb-service-catalyst-cloud.sh in the repo.