### PR TITLE
Fix job cloud-provider-openstack-acceptance-test-lb-octavia

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
@@ -31,6 +31,9 @@
     - name: Upload openstack-cloud-controller-manager image
       shell: docker push {{ dockerhub.username }}/openstack-cloud-controller-manager:{{ zuul.change }}
 
+    - name: THIS TASK IS ONLY FOR DEBUGGING PURPOSE, SHOULD BE REMOVED REFORE MERGE.
+      pause:
+
     - name: Wait until openstack-cloud-controller-manager is avaialble for patching
       shell:
         executable: /bin/bash

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -818,10 +818,12 @@
       Run lb acceptance tests of cloud-provider-openstack
     run: playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
     post-run: playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/post.yaml
-    nodeset: ubuntu-xenial-vexxhost-lb
+    nodeset: ubuntu-bionic
     secrets:
-      - vexxhost_credentials
+      - catalyst_credentials
       - kubeconfig
+    vars:
+      go_version: '1.13.4'
 
 - job:
     name: cloud-provider-openstack-acceptance-test-keystone-authentication-authorization


### PR DESCRIPTION
- Install golang 1.13
- Use ubuntu-bionic nodeset.
- Use catalyst_credentials
- Pause the ansible playbook for debugging purpose, the pause task will
  be removed afterwards