### PR TITLE
Add dockerhub secret for occ-test-lb-octavia

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -822,6 +822,7 @@
     secrets:
       - catalyst_credentials
       - kubeconfig
+      - dockerhub
 
 - job:
     name: cloud-provider-openstack-acceptance-test-keystone-authentication-authorization


### PR DESCRIPTION
Fixes the error:
```
The task includes an option with an undefined variable. The error was: 'dockerhub' is undefined
```