### PR TITLE
Drop elasticsearch2

### DIFF
--- a/playbooks/flink-end-to-end-test/build_and_test_kafka_gelly_and_connectors.yaml
+++ b/playbooks/flink-end-to-end-test/build_and_test_kafka_gelly_and_connectors.yaml
@@ -65,7 +65,6 @@
           flink-formats/flink-avro,flink-formats/flink-parquet,flink-formats/flink-sequence-file,flink-formats/flink-json,\
           flink-formats/flink-csv,flink-connectors/flink-hbase,flink-connectors/flink-hcatalog,\
           flink-connectors/flink-hadoop-compatibility,flink-connectors/flink-jdbc,flink-connectors,\
-          flink-connectors/flink-connector-elasticsearch2,\
           flink-connectors/flink-connector-elasticsearch5,flink-connectors/flink-connector-elasticsearch6,\
           flink-connectors/flink-connector-elasticsearch7,flink-connectors/flink-sql-connector-elasticsearch6,\
           flink-connectors/flink-sql-connector-elasticsearch7,flink-connectors/flink-connector-elasticsearch-base,\
@@ -96,7 +95,6 @@
           flink-formats/flink-avro,flink-formats/flink-parquet,flink-formats/flink-sequence-file,flink-formats/flink-json,\
           flink-formats/flink-csv,flink-connectors/flink-hbase,flink-connectors/flink-hcatalog,\
           flink-connectors/flink-hadoop-compatibility,flink-connectors/flink-jdbc,flink-connectors,\
-          flink-connectors/flink-connector-elasticsearch2,\
           flink-connectors/flink-connector-elasticsearch5,flink-connectors/flink-connector-elasticsearch6,\
           flink-connectors/flink-connector-elasticsearch7,flink-connectors/flink-sql-connector-elasticsearch6,\
           flink-connectors/flink-sql-connector-elasticsearch7,flink-connectors/flink-connector-elasticsearch-base,\

--- a/playbooks/flink-end-to-end-test/build_and_test_misc.yaml
+++ b/playbooks/flink-end-to-end-test/build_and_test_misc.yaml
@@ -57,7 +57,7 @@
           !flink-formats/flink-avro,!flink-formats/flink-parquet,!flink-formats/flink-sequence-file,!flink-formats/flink-json,\
           !flink-formats/flink-csv,!flink-connectors/flink-hbase,!flink-connectors/flink-hcatalog,\
           !flink-connectors/flink-hadoop-compatibility,!flink-connectors/flink-jdbc,!flink-connectors,\
-          !flink-connectors/flink-connector-cassandra,!flink-connectors/flink-connector-elasticsearch2,\
+          !flink-connectors/flink-connector-cassandra,\
           !flink-connectors/flink-connector-elasticsearch5,!flink-connectors/flink-connector-elasticsearch6,\
           !flink-connectors/flink-connector-elasticsearch7,!flink-connectors/flink-sql-connector-elasticsearch6,\
           !flink-connectors/flink-sql-connector-elasticsearch7,!flink-connectors/flink-connector-elasticsearch-base,\


### PR DESCRIPTION
elasticsearch2 is removed from Flink already.