### PR TITLE
Use ``demo`` user/project for csi-manila-secrets

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-csi-manila/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-csi-manila/run.yaml
@@ -140,12 +140,16 @@
           metadata:
             name: csi-manila-secrets
             namespace: default
+          # Use the devstack ``demo`` user in the ``demo`` project rather than ``admin``
+          # since regular users should be able to use the cloud-provider-openstack
+          # APIs without OpenStack administrative privileges.  Devstack sets up
+          # up the same password for both users.
           stringData:
             os-authURL: "$OS_AUTH_URL"
             os-region: "$OS_REGION_NAME"
-            os-userName: "$OS_USERNAME"
+            os-userName: "demo"
             os-password: "$OS_PASSWORD"
-            os-projectName: "$OS_PROJECT_NAME"
+            os-projectName: "demo"
             os-domainID: "$OS_USER_DOMAIN_ID"
           YAML
 


### PR DESCRIPTION
Using the ``admin`` user and project allows false-positive test results if the code being tested uses OpenStack APIs that are not allowed for non-administrators, so use the regular ``demo`` user and project set up by devstack instead.