### PR TITLE
[CPO] Fix the CI job k8s-cinder

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-k8s-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-k8s-cinder/run.yaml
@@ -93,7 +93,7 @@
           if timeout 300 bash -c '
               while :
               do
-                  [[ $({{ kubectl }} describe pods web | awk "/^Status:/ {print \$2}") == Running ]] && break
+                  [[ $({{ kubectl }} get pod web | grep web | awk "{print \$3}") == Running ]] && break
                   sleep 1
               done
               '


### PR DESCRIPTION
Sometimes from the log, I can see the following:

```
+ /home/zuul/src/k8s.io/kubernetes/cluster/kubectl.sh describe pods web
Name:         web
Namespace:    default
Priority:     0
Node:         ubuntu-xenial-citynetwork-citynetwork-openlab-0000121863/192.168.0.12
Start Time:   Wed, 04 Mar 2020 21:55:34 +0000
Labels:       <none>
Annotations:  Status:  Running
```

which leads to job failure.

This patch fixes the way to get the pod status.