### PR TITLE
Adopt new make targets from OpenStack cloud provider

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
@@ -12,6 +12,7 @@
           set -e
           set -o pipefail
 
+          export ARCH=${ARCH:-amd64}
           # Build cloud-provider-openstack binaries
           make build
 

--- a/playbooks/cloud-provider-openstack-acceptance-test-csi-manila/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-csi-manila/run.yaml
@@ -33,6 +33,8 @@
           export ALLOW_PRIVILEGED=true
           # Just kick off all the processes and drop down to the command line
           export ENABLE_DAEMON=true
+          export ARCH=${ARCH:-amd64}
+          export VERSION=${VERSION:-latest}
 
           # We need this for snapshots support, at least for now
           export FEATURE_GATES="VolumeSnapshotDataSource=true"
@@ -58,10 +60,8 @@
           curl -L https://git.io/get_helm.sh | bash
           helm init --client-only
 
-          # Build CSI Manila plugin
-          make manila-csi-plugin
-          # Build a Docker image
-          mv manila-csi-plugin cluster/images/manila-csi-plugin/ && docker build -t manila-csi-plugin cluster/images/manila-csi-plugin
+          # Build CSI Manila plugin binary and Docker image
+          make image-manila-csi-plugin
 
           #
           # Deployment

--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -11,10 +11,8 @@
           set -x
           set -e
           set -o pipefail
-
           # Specify target architecture to build binaries and images
           export ARCH=${ARCH:-amd64}
-
           # Build cloud-provider-openstack binaries
           make build
 
@@ -52,7 +50,7 @@
           # DO NOT change the location of the cloud-config file. It is important for the old cinder provider to work
           export CLOUD_CONFIG=/etc/kubernetes/cloud-config
           # Specify the OCCM binary
-          export EXTERNAL_CLOUD_PROVIDER_BINARY="$PWD/openstack-cloud-controller-manager-$ARCH"
+          export EXTERNAL_CLOUD_PROVIDER_BINARY="$PWD/openstack-cloud-controller-manager"
 
           # location of where the kubernetes processes log their output
           mkdir -p '{{ k8s_log_dir }}'
@@ -165,24 +163,20 @@
             set -o pipefail
 
             export LOG_DIR='{{ k8s_log_dir }}'
-            export REGISTRY=docker.io/k8scloudprovider
-            export VERSION=latest
-            # Specify target architecture to build binaries and images
-            export ARCH=${ARCH:-amd64}
+            export REGISTRY=${REGISTRY:-docker.io/k8scloudprovider}
+            export ARCHS=${ARCHS:-amd64}
+            export VERSION=${VERSION:-latest}
+            # Docker login information here and no_log tag below will be removed once
+            # https://github.com/kubernetes/cloud-provider-openstack/pull/967 landed
+            export DOCKER_PASSWORD='{{ dockerhub.password }}'
+            export DOCKER_USERNAME='{{ dockerhub.username }}'
 
+            make upload-images 2>&1 | tee $LOG_DIR/image-build-upload.log
 
-            make images 2>&1 | tee $LOG_DIR/image-build-upload.log
-
-            docker push ${REGISTRY}/openstack-cloud-controller-manager-${ARCH}:${VERSION} | tee $LOG_DIR/image-build-upload.log
-            docker push ${REGISTRY}/cinder-csi-plugin-${ARCH}:${VERSION} | tee $LOG_DIR/image-build-upload.log
-            docker push ${REGISTRY}/k8s-keystone-auth-${ARCH}:${VERSION} | tee $LOG_DIR/image-build-upload.log
-            docker push ${REGISTRY}/octavia-ingress-controller-${ARCH}:${VERSION} | tee $LOG_DIR/image-build-upload.log
-            docker push ${REGISTRY}/manila-csi-plugin-${ARCH}:${VERSION} | tee $LOG_DIR/image-build-upload.log
-            docker push ${REGISTRY}/manila-provisioner-${ARCH}:${VERSION} | tee $LOG_DIR/image-build-upload.log
-            docker push ${REGISTRY}/magnum-auto-healer-${ARCH}:${VERSION} | tee $LOG_DIR/image-build-upload.log
           else
             exit 0;
           fi
         executable: /bin/bash
         chdir: '{{ k8s_os_provider_src_dir }}'
       environment: '{{ global_env }}'
+      no_log: yes

--- a/playbooks/cloud-provider-openstack-acceptance-test-flexvolume-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-flexvolume-cinder/run.yaml
@@ -25,6 +25,8 @@
           set -e
           set -o pipefail
 
+          export ARCH=${ARCH:-amd64}
+
           # Build cloud-provider-openstack binaries
           make build
 

--- a/playbooks/cloud-provider-openstack-acceptance-test-k8s-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-k8s-cinder/run.yaml
@@ -12,6 +12,7 @@
           set -e
           set -o pipefail
 
+          export ARCH=${ARCH:-amd64}
           # Build cloud-provider-openstack binaries
           make build
 

--- a/playbooks/cloud-provider-openstack-acceptance-test-keystone-authentication-authorization/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-keystone-authentication-authorization/run.yaml
@@ -15,8 +15,10 @@
           set -e
           set -o pipefail
 
+          export ARCH=${ARCH:-amd64}
+          export BUILD_CMDS='k8s-keystone-auth openstack-cloud-controller-manager'
           # Build cloud-provider-openstack binaries
-          BUILD_CMDS=k8s-keystone-auth make build
+          make build
 
           apt-get install python-pip -y
           pip install -U python-openstackclient
@@ -153,7 +155,7 @@
 
           # Start k8s-keystone-auth webhook service
           [[ "$OS_AUTH_URL" =~ "v3" ]] && keystone_url=${OS_AUTH_URL} || keystone_url=${OS_AUTH_URL}/v3
-          nohup ./k8s-keystone-auth-amd64 \
+          nohup ./k8s-keystone-auth \
                 --tls-cert-file /var/run/kubernetes/serving-kube-apiserver.crt \
                 --tls-private-key-file /var/run/kubernetes/serving-kube-apiserver.key \
                 --policy-configmap-name keystone-auth-policy \

--- a/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
@@ -55,14 +55,21 @@
       shell: docker login -u {{ dockerhub.username }} -p {{ dockerhub.password }}
       no_log: yes
 
-    - name: Build openstack-cloud-controller-manager image
+    - name: Build and upload openstack-cloud-controller-manager image
       shell:
-        cmd: make image-controller-manager REGISTRY={{ dockerhub.username }} VERSION={{ zuul.change }}
+        cmd: |
+          export BUILD_CMDS=openstack-cloud-controller-manager
+          export IMAGE_NAMES=openstack-cloud-controller-manager
+          export ARCHS=${ARCHS:-amd64}
+          # Docker login information here and no_log tag below will be removed once
+          # https://github.com/kubernetes/cloud-provider-openstack/pull/967 landed
+          export DOCKER_PASSWORD='{{ dockerhub.password }}'
+          export DOCKER_USERNAME='{{ dockerhub.username }}'
+
+          REGISTRY={{ dockerhub.username }} VERSION={{ zuul.change }} make upload-images
         chdir: '{{ k8s_os_provider_src_dir }}'
       environment: '{{ global_env }}'
-
-    - name: Upload openstack-cloud-controller-manager image
-      shell: docker push {{ dockerhub.username }}/openstack-cloud-controller-manager:{{ zuul.change }}
+      no_log: yes
 
     - name: Wait until openstack-cloud-controller-manager is avaialble for patching
       shell:

--- a/playbooks/cloud-provider-openstack-acceptance-test-manila-provisioner/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-manila-provisioner/run.yaml
@@ -20,8 +20,11 @@
           set -e
           set -o pipefail
 
+          export ARCH=${ARCH:-amd64}
+          export BUILD_CMDS=manila-provisioner
+
           # Build manila-provisioner binary
-          make manila-provisioner
+          make build
 
           export API_HOST_IP=$(ip route get 1.1.1.1 | awk '{print $7}')
           export KUBELET_HOST="0.0.0.0"

--- a/playbooks/cloud-provider-openstack-acceptance-test-standalone-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-standalone-cinder/run.yaml
@@ -15,6 +15,8 @@
           set -e
           set -o pipefail
 
+          # Specify target architecture to build binaries and images
+          export ARCH=${ARCH:-amd64}
           # Build cloud-provider-openstack binaries
           make build
 

--- a/playbooks/cloud-provider-openstack-e2e-test-csi-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-e2e-test-csi-cinder/run.yaml
@@ -47,7 +47,7 @@
           # DO NOT change the location of the cloud-config file. It is important for the old cinder provider to work
           export CLOUD_CONFIG=/etc/kubernetes/cloud-config
           # Specify the OCCM binary
-          export EXTERNAL_CLOUD_PROVIDER_BINARY="$PWD/openstack-cloud-controller-manager-$ARCH"
+          export EXTERNAL_CLOUD_PROVIDER_BINARY="$PWD/openstack-cloud-controller-manager"
 
           # location of where the kubernetes processes log their output
           mkdir -p '{{ k8s_log_dir }}'

--- a/playbooks/cloud-provider-openstack-multinode-csi-migration-test/pre.yaml
+++ b/playbooks/cloud-provider-openstack-multinode-csi-migration-test/pre.yaml
@@ -199,7 +199,7 @@
   roles:
     - export-cloud-openrc
   tasks:
-    - name: build cinder-csi from master
+    - name: build cinder-csi from master and push cluster-local-build of cinder-csi-plugin to local registry
       environment: '{{ global_env }}'
       args:
         executable: /bin/bash
@@ -209,16 +209,20 @@
           set -o pipefail
           set -ex
           # Specify target architecture to build binaries and images
-          export ARCH=${ARCH:-amd64}
-          make build-cmd-cinder-csi-plugin
-          docker build -t {{ registry_ip }}:32000/k8scloudprovider/cinder-csi-plugin:latest -f cluster/images/cinder-csi-plugin/Dockerfile.build .
+          export ARCHS=${ARCHS:-amd64}
+          export VERSION=${VERSION:-latest}
+          export REGISTRY=${REGISTRY:-{{ registry_ip }}:32000/k8scloudprovider}
+          export BUILD_CMDS=cinder-csi-plugin
+          export IMAGE_NAMES=cinder-csi-plugin
 
-    - name: push cluster-local-build of cinder-csi-plugin to local registry
-      shell:
-        cmd: |
-          docker push {{ registry_ip }}:32000/k8scloudprovider/cinder-csi-plugin:latest
+          # Docker login information here and no_log tag below will be removed once
+          # https://github.com/kubernetes/cloud-provider-openstack/pull/967 landed
+          export DOCKER_PASSWORD='{{ dockerhub.password }}'
+          export DOCKER_USERNAME='{{ dockerhub.username }}'
+          make upload-images
       retries: 5
       delay: 5
+      no_log: yes
 
     - name: ship kustomization.yaml to use cinder-csi-plugin image from in-cluster registry
       copy:


### PR DESCRIPTION
Since we changed our makefile in kubernetes/cloud-provider-openstack [1]
We need to update tests accordingly.

This also correct [2] to use consist image names as previously have.
(So we still will have one same old docker image name)

[1] https://github.com/kubernetes/cloud-provider-openstack/pull/910
[2] https://github.com/theopenlab/openlab-zuul-jobs/commit/95ca894d4ffa44a4f6a8389eb317003cbe0d3c5c