### PR TITLE
Allow tag image in test to avoid push image manifest

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-csi-manila/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-csi-manila/run.yaml
@@ -62,6 +62,11 @@
 
           # Build CSI Manila plugin binary and Docker image
           make image-manila-csi-plugin
+          if [[ -z "$(docker images -q k8scloudprovider/manila-csi-plugin:$VERSION 2> /dev/null)" ]]; then
+              # add tag without architecture so we don't need to push manifests
+              docker image tag k8scloudprovider/manila-csi-plugin-$ARCH:$VERSION k8scloudprovider/manila-csi-plugin:$VERSION
+          fi
+
 
           #
           # Deployment

--- a/playbooks/cloud-provider-openstack-e2e-test-csi-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-e2e-test-csi-cinder/run.yaml
@@ -95,6 +95,11 @@
           # Build latest images from source
           VERSION=latest make image-cinder-csi-plugin
 
+          if [[ -z "$(docker images -q k8scloudprovider/cinder-csi-plugin:$VERSION 2> /dev/null)" ]]; then
+              # add tag without architecture so we don't need to push manifests
+              docker image tag k8scloudprovider/cinder-csi-plugin-$ARCH:$VERSION k8scloudprovider/cinder-csi-plugin:$VERSION
+          fi
+
           # Replace custom cloud config
           {
               cloud_cfg=$(base64 -w 0 ${CLOUD_CONFIG})


### PR DESCRIPTION
This is targeting recent failure caused by https://github.com/kubernetes/cloud-provider-openstack/pull/910

This also related to https://github.com/kubernetes/cloud-provider-openstack/pull/967

This allow us to run tests in local without push any manifest.

Current design for multi-arch will generate image without architecture
in name with pushing image manifest.

This change directly tag image in tests so we can test image locally
without push anything up.