### PR TITLE
[CPO] Override image repository and tag for CSI Manila to always use the latest build

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-csi-manila/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-csi-manila/run.yaml
@@ -121,6 +121,10 @@
           # Deploy CSI Manila
           cat << YAML >> override-helm-values.yaml
           nameOverride: manila-csi
+          csimanila:
+            image:
+              repository: k8scloudprovider/manila-csi-plugin
+              tag: latest
           shareProtocols:
             - protocolSelector: NFS
               fwdNodePluginEndpoint:


### PR DESCRIPTION
This PR forces Helm to deploy CSI Manila with `k8scloudprovider/manila-csi-plugin:latest` image.

To be merged after https://github.com/theopenlab/openlab-zuul-jobs/pull/821

/cc @tombarron @gouthampacha 