### PR TITLE
[CPO] fix perodic jobs: remove extra docker login

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -166,10 +166,6 @@
             export REGISTRY=${REGISTRY:-docker.io/k8scloudprovider}
             export ARCHS=${ARCHS:-amd64}
             export VERSION=${VERSION:-latest}
-            # Docker login information here and no_log tag below will be removed once
-            # https://github.com/kubernetes/cloud-provider-openstack/pull/967 landed
-            export DOCKER_PASSWORD='{{ dockerhub.password }}'
-            export DOCKER_USERNAME='{{ dockerhub.username }}'
 
             make upload-images 2>&1 | tee $LOG_DIR/image-build-upload.log
 
@@ -179,4 +175,3 @@
         executable: /bin/bash
         chdir: '{{ k8s_os_provider_src_dir }}'
       environment: '{{ global_env }}'
-      no_log: yes

--- a/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
@@ -61,15 +61,10 @@
           export BUILD_CMDS=openstack-cloud-controller-manager
           export IMAGE_NAMES=openstack-cloud-controller-manager
           export ARCHS=${ARCHS:-amd64}
-          # Docker login information here and no_log tag below will be removed once
-          # https://github.com/kubernetes/cloud-provider-openstack/pull/967 landed
-          export DOCKER_PASSWORD='{{ dockerhub.password }}'
-          export DOCKER_USERNAME='{{ dockerhub.username }}'
 
           REGISTRY={{ dockerhub.username }} VERSION={{ zuul.change }} make upload-images
         chdir: '{{ k8s_os_provider_src_dir }}'
       environment: '{{ global_env }}'
-      no_log: yes
 
     - name: Wait until openstack-cloud-controller-manager is avaialble for patching
       shell:

--- a/playbooks/cloud-provider-openstack-multinode-csi-migration-test/pre.yaml
+++ b/playbooks/cloud-provider-openstack-multinode-csi-migration-test/pre.yaml
@@ -215,14 +215,9 @@
           export BUILD_CMDS=cinder-csi-plugin
           export IMAGE_NAMES=cinder-csi-plugin
 
-          # Docker login information here and no_log tag below will be removed once
-          # https://github.com/kubernetes/cloud-provider-openstack/pull/967 landed
-          export DOCKER_PASSWORD='{{ dockerhub.password }}'
-          export DOCKER_USERNAME='{{ dockerhub.username }}'
           make upload-images
       retries: 5
       delay: 5
-      no_log: yes
 
     - name: ship kustomization.yaml to use cinder-csi-plugin image from in-cluster registry
       copy:


### PR DESCRIPTION
Since [1] merged, we can remove extra docker logins and no_log tags.

[1] https://github.com/kubernetes/cloud-provider-openstack/pull/967