### PR TITLE
[CPO] Pin golang version to 1.13.4

### DIFF
--- a/playbooks/cloud-provider-openstack-unittest/run.yaml
+++ b/playbooks/cloud-provider-openstack-unittest/run.yaml
@@ -1,7 +1,8 @@
 - hosts: all
   become: yes
   roles:
-    - config-golang
+    - role: config-golang
+      go_version: '1.13.4'
     - export-cloud-openrc
   tasks:
     - name: Run unit tests with cloud-provider-openstack


### PR DESCRIPTION
To fix the error `note: module requires Go 1.13`, see https://logs.openlabtesting.org/logs/91/991/d7f000b8cc6765485abfa11d1213f1604122d724/cloud-provider-openstack-unittest/cloud-provider-openstack-unittest/62739dc/job-output.txt.gz