### PR TITLE
[CPO] Remove glide module installation

### DIFF
--- a/playbooks/cloud-provider-openstack-unittest/run.yaml
+++ b/playbooks/cloud-provider-openstack-unittest/run.yaml
@@ -12,7 +12,6 @@
           set -e
           set -o pipefail
 
-          go get -u github.com/Masterminds/glide
           TESTARGS='-v' make test 2>&1 | tee $TEST_RESULTS_TXT
         executable: /bin/bash
         chdir: '{{ k8s_os_provider_src_dir }}'


### PR DESCRIPTION
Fix the job failure of cloud-provider-openstack-unittest, we don't need to install glide any more:

```
2020-03-27 05:12:31.316559 | ubuntu-xenial-citynetwork | + go get -u github.com/Masterminds/glide
2020-03-27 05:12:36.704129 | ubuntu-xenial-citynetwork | go: finding github.com/Masterminds/glide v0.13.3
2020-03-27 05:12:36.808223 | ubuntu-xenial-citynetwork | go: downloading github.com/Masterminds/glide v0.13.3
2020-03-27 05:12:37.329723 | ubuntu-xenial-citynetwork | go: extracting github.com/Masterminds/glide v0.13.3
2020-03-27 05:12:37.521093 | ubuntu-xenial-citynetwork | go: downloading gopkg.in/yaml.v2 v2.2.7
2020-03-27 05:12:37.532296 | ubuntu-xenial-citynetwork | go: downloading github.com/mitchellh/go-homedir v1.1.0
2020-03-27 05:12:37.568332 | ubuntu-xenial-citynetwork | go: finding github.com/Masterminds/vcs v1.13.1
2020-03-27 05:12:37.626867 | ubuntu-xenial-citynetwork | go: finding github.com/Masterminds/semver v1.5.0
2020-03-27 05:12:37.626995 | ubuntu-xenial-citynetwork | go: finding github.com/codegangsta/cli v1.22.3
2020-03-27 05:12:37.637223 | ubuntu-xenial-citynetwork | go: downloading github.com/Masterminds/semver v1.5.0
2020-03-27 05:12:37.637362 | ubuntu-xenial-citynetwork | go: extracting github.com/mitchellh/go-homedir v1.1.0
2020-03-27 05:12:37.637453 | ubuntu-xenial-citynetwork | go: downloading github.com/Masterminds/vcs v1.13.1
2020-03-27 05:12:37.647902 | ubuntu-xenial-citynetwork | go: downloading github.com/codegangsta/cli v1.22.3
2020-03-27 05:12:37.939815 | ubuntu-xenial-citynetwork | go: extracting gopkg.in/yaml.v2 v2.2.7
2020-03-27 05:12:38.050536 | ubuntu-xenial-citynetwork | go: extracting github.com/Masterminds/vcs v1.13.1
2020-03-27 05:12:38.112627 | ubuntu-xenial-citynetwork | go: extracting github.com/Masterminds/semver v1.5.0
2020-03-27 05:12:38.113591 | ubuntu-xenial-citynetwork | go: extracting github.com/codegangsta/cli v1.22.3
2020-03-27 05:12:38.225404 | ubuntu-xenial-citynetwork | go: github.com/Masterminds/glide imports
2020-03-27 05:12:38.225611 | ubuntu-xenial-citynetwork | 	github.com/codegangsta/cli: github.com/codegangsta/cli@v1.22.3: parsing go.mod:
2020-03-27 05:12:38.225717 | ubuntu-xenial-citynetwork | 	module declares its path as: github.com/urfave/cli
2020-03-27 05:12:38.225813 | ubuntu-xenial-citynetwork | 	        but was required as: github.com/codegangsta/cli
```