### PR TITLE
CPO: Update etcd version

### DIFF
--- a/roles/install-k8s/defaults/main.yaml
+++ b/roles/install-k8s/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
 k8s_version: 'master'
-etcd_version: 'v3.4.4'
+etcd_version: 'v3.4.7'
 k8s_with_hyperkube:
   - release-1.10
   - release-1.11


### PR DESCRIPTION
latest k8s needs 3.4.7 version. updating the same.