### PR TITLE
Set higher openstack-acceptance-test-lbaas timeout

### DIFF
--- a/playbooks/terraform-provider-openstack-acceptance-test-lbaas/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-lbaas/run.yaml
@@ -40,7 +40,7 @@
           export OS_LB_ENVIRONMENT=1 # for LBaaS tests
           testcases=`go test ./openstack/ -v -list 'Acc'`
           testcases=`echo "$testcases" | sed '$d' | grep LB`
-          echo "$testcases" | xargs -t -n100 sh -c 'TF_LOG=DEBUG TF_ACC=1 go test ./openstack -v -timeout 120m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
+          echo "$testcases" | xargs -t -n100 sh -c 'TF_LOG=DEBUG TF_ACC=1 go test ./openstack -v -timeout 300m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'
       environment: '{{ global_env }}'

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -272,7 +272,7 @@
     description: |
       Run terraform-provider-openstack lbaas acceptance test on master branch
     run: playbooks/terraform-provider-openstack-acceptance-test-lbaas/run.yaml
-    timeout: 14400 # 4h
+    timeout: 25200 # 7h
     nodeset: ubuntu-bionic
 
 - job:


### PR DESCRIPTION
Set 300m timeout for test run in
playbooks/terraform-provider-openstack-acceptance-test-lbaas/run.yaml.

Reference: https://github.com/theopenlab/openlab/issues/525