### PR TITLE
manila-csi-plugin: helm chart was moved to charts/

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-csi-manila/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-csi-manila/run.yaml
@@ -136,7 +136,7 @@
                 dir: /var/lib/kubelet/plugins/csi-nfsplugin
                 sockFile: csi.sock
           YAML
-          helm template examples/manila-csi-plugin/helm-deployment -f override-helm-values.yaml --name sharedstorage | '{{ kubectl }}' create -f -
+          helm template charts/manila-csi-plugin -f override-helm-values.yaml --name sharedstorage | '{{ kubectl }}' create -f -
 
           #
           # Prepare the prerequisites for the tests


### PR DESCRIPTION
https://github.com/kubernetes/cloud-provider-openstack/pull/1110 moves the helm chart for manila-csi-plugin to `charts` directory. This PR reflects this change.

cc @strigazi