### PR TITLE
[CPO] Remove post run for e2e conformance

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -571,7 +571,6 @@
     description: |
       Run Kubernetes E2E Conformance tests against a multinode Kubernetes cluster
     run: playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
-    post-run: playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/post.yaml
     nodeset: ubuntu-xenial-k8s-cluster-cpo
     secrets:
       - citynetwork_credentials


### PR DESCRIPTION
This commit removes post run for e2e conformance , as its been removed.