### PR TITLE
Fix master error during verify the whl with MNIST test

### DIFF
--- a/playbooks/tensorflow-arm-build/run.yaml
+++ b/playbooks/tensorflow-arm-build/run.yaml
@@ -194,7 +194,7 @@
           set -ex
           export MPLLOCALFREETYPE=1
           sudo apt install -y libpng-dev
-          pip3 install matplotlib tensorflow_datasets
+          pip3 install matplotlib tensorflow_datasets==3.1.0
           wget https://raw.githubusercontent.com/bzhaoopenstack/dockertoy/master/tests/ai/examples/test_mnist.py
           python3 ./test_mnist.py
       args:


### PR DESCRIPTION
The upstream issue is
https://github.com/tensorflow/tensorflow/issues/38477

So we have only to downgrade the tensorflow_datasets version from the default 3.2.1 to 3.1.0.

Once the upstream issue is resolved. Will remove this limitation.