### PR TITLE
Fix setup server error in gpdb with no module "psutil" error

### DIFF
--- a/playbooks/gpdb-installcheck-world-tests-on-arm64/run.yaml
+++ b/playbooks/gpdb-installcheck-world-tests-on-arm64/run.yaml
@@ -83,7 +83,7 @@
         pip install setuptools
         pip install wheel
         pip install --no-use-pep517 --user "pyopenssl>=19.0.0"
-        pip install --no-use-pep517 --user --pre psutil
+        pip install --no-use-pep517 --user --pre psutil==5.7.0
         pip install --no-use-pep517 --user lockfile
         pip install --no-use-pep517 --no-binary :all: pynacl
         pip install --no-use-pep517 --user paramiko || true


### PR DESCRIPTION
The upstream issue https://github.com/giampaolo/psutil/issues/1268
Downgrade the psutil from 5.7.2 to 5.7.0 during testing when using py27.