### PR TITLE
Enable TF release CI for tf 2.1.0 and 1.15.3 stable branches

### DIFF
--- a/playbooks/tensorflow-arm-build/run.yaml
+++ b/playbooks/tensorflow-arm-build/run.yaml
@@ -1,5 +1,85 @@
 - hosts: all
   tasks:
+    - name: Install python3.5
+      become: yes
+      shell:
+        cmd: |
+          add-apt-repository ppa:deadsnakes/ppa -y
+          apt update
+          apt install -y python3.5 python3.5-dev
+
+          rm /usr/bin/python3
+          ln -s /usr/bin/python3.5 /usr/bin/python3
+
+          curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+          python3 get-pip.py
+      args:
+        executable: /bin/bash
+        chdir: '/opt'
+      environment: '{{ global_env }}'
+      when:
+        global_env.PYTHON == 'v3.5'
+
+    - name: Install python3.6
+      become: yes
+      shell:
+        cmd: |
+          add-apt-repository ppa:deadsnakes/ppa -y
+          apt update
+          apt install -y python3.6 python3.6-dev
+
+          rm /usr/bin/python3
+          ln -s /usr/bin/python3.6 /usr/bin/python3
+
+          curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+          python3 get-pip.py
+      args:
+        executable: /bin/bash
+        chdir: '/opt'
+      environment: '{{ global_env }}'
+      when:
+        global_env.PYTHON == 'v3.6'
+
+    - name: Install python3.7
+      become: yes
+      shell:
+        cmd: |
+          add-apt-repository ppa:deadsnakes/ppa -y
+          apt update
+          apt install -y python3.7 python3.7-dev
+
+          rm /usr/bin/python3
+          ln -s /usr/bin/python3.7 /usr/bin/python3
+
+          curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+          python3 get-pip.py
+      args:
+        executable: /bin/bash
+        chdir: '/opt'
+      environment: '{{ global_env }}'
+      when:
+        global_env.PYTHON == 'v3.7'
+
+    - name: Install python3.8
+      become: yes
+      shell:
+        cmd: |
+          add-apt-repository ppa:deadsnakes/ppa -y
+          apt update
+          apt install -y python3.8 python3.8-dev
+
+          rm /usr/bin/python3
+          ln -s /usr/bin/python3.8 /usr/bin/python3
+
+          curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+          python3 get-pip.py
+      args:
+        executable: /bin/bash
+        chdir: '/opt'
+      environment: '{{ global_env }}'
+      when:
+        global_env.PYTHON == 'v3.8'
+
     - name: Install the necessary libraries via apt
       become: true
       shell:
@@ -11,9 +91,6 @@
           zip \
           unzip \
           gcc \
-          python3 \
-          python3-dev \
-          python3-pip \
           libhdf5-serial-dev \
           git \
           pkg-config \
@@ -105,7 +182,9 @@
           virtualenv --python=python3.6 ~/.env/tensorflow/
           source ~/.env/tensorflow/bin/activate
           release={{ global_env.RELEASE }}
-          if [ $release != 'master' ]; then
+          if [ $release == 'v1.15.3' ]; then
+              BUILD_OPTS="--curses=no"
+          elif [ $release != 'master' ]; then
               BUILD_OPTS=""
           else
               BUILD_OPTS="--config=noaws --config=nogcp --config=nonccl"
@@ -133,9 +212,9 @@
           pip3 install keras_preprocessing
           bazel clean --expunge
           bazel build --config=opt ${BUILD_OPTS} //tensorflow/tools/pip_package:build_pip_package \
-          --local_ram_resources=10240 --local_cpu_resources=4 --verbose_failures
+          --local_ram_resources=12240 --local_cpu_resources=6 --verbose_failures
           mkdir tensorflow-pkg
-          bazel-bin/tensorflow/tools/pip_package/build_pip_package ./tensorflow-pkg
+          bazel-bin/tensorflow/tools/pip_package/build_pip_package --cpu ./tensorflow-pkg
       args:
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'
@@ -149,7 +228,7 @@
     - name: Copy the built file
       shell:
         cmd: |
-          cp tensorflow-pkg/tensorflow-*.whl "{{ ansible_user_dir }}/workspace/test_results/"
+          cp tensorflow-pkg/tensorflow*.whl "{{ ansible_user_dir }}/workspace/test_results/"
       args:
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}'
@@ -200,3 +279,22 @@
       args:
         executable: /bin/bash
         chdir: '{{ zuul.project.src_dir }}/tensorflow-pkg'
+      environment: '{{ global_env }}'
+      when:
+        global_env.RELEASE != 'v1.15.3'
+
+    - name: Verify Tensorflow v1.15.3 with MNIST test
+      shell:
+        cmd: |
+          set -ex
+          export MPLLOCALFREETYPE=1
+          sudo apt install -y libpng-dev
+          pip3 install matplotlib tensorflow_datasets==3.1.0 openbayestool
+          wget https://raw.githubusercontent.com/bzhaoopenstack/dockertoy/master/tests/ai/examples/test_mnist_115.sh
+          bash ./test_mnist_115.sh
+      args:
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}/tensorflow-pkg'
+      environment: '{{ global_env }}'
+      when:
+        global_env.RELEASE == 'v1.15.3'

--- a/playbooks/tensorflow-arm-build/run.yaml
+++ b/playbooks/tensorflow-arm-build/run.yaml
@@ -6,11 +6,10 @@
         cmd: |
           add-apt-repository ppa:deadsnakes/ppa -y
           apt update
-          apt install -y python3.5 python3.5-dev
-
+          apt autoremove -y python3-apt
+          apt install -y python3.5 python3.5-dev python3-apt
           rm /usr/bin/python3
           ln -s /usr/bin/python3.5 /usr/bin/python3
-
           curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
           python3 get-pip.py
       args:
@@ -26,11 +25,10 @@
         cmd: |
           add-apt-repository ppa:deadsnakes/ppa -y
           apt update
-          apt install -y python3.6 python3.6-dev
-
+          apt autoremove -y python3-apt
+          apt install -y python3.6 python3.6-dev python3-apt
           rm /usr/bin/python3
           ln -s /usr/bin/python3.6 /usr/bin/python3
-
           curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
           python3 get-pip.py
       args:
@@ -46,11 +44,10 @@
         cmd: |
           add-apt-repository ppa:deadsnakes/ppa -y
           apt update
-          apt install -y python3.7 python3.7-dev
-
+          apt autoremove -y python3-apt
+          apt install -y python3.7 python3.7-dev python3-apt
           rm /usr/bin/python3
           ln -s /usr/bin/python3.7 /usr/bin/python3
-
           curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
           python3 get-pip.py
       args:
@@ -66,11 +63,10 @@
         cmd: |
           add-apt-repository ppa:deadsnakes/ppa -y
           apt update
-          apt install -y python3.8 python3.8-dev
-
+          apt autoremove -y python3-apt
+          apt install -y python3.8 python3.8-dev python3-apt
           rm /usr/bin/python3
           ln -s /usr/bin/python3.8 /usr/bin/python3
-
           curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
           python3 get-pip.py
       args:
@@ -87,7 +83,6 @@
           apt update && \
           apt install -y build-essential \
           openjdk-8-jdk \
-          python \
           zip \
           unzip \
           gcc \
@@ -179,7 +174,7 @@
       shell:
         cmd: |
           set -xe
-          virtualenv --python=python3.6 ~/.env/tensorflow/
+          virtualenv --python=python3 ~/.env/tensorflow/
           source ~/.env/tensorflow/bin/activate
           release={{ global_env.RELEASE }}
           if [ $release == 'v1.15.3' ]; then
@@ -251,6 +246,11 @@
             artifacts:
               - name: "{{ whl_file_name }}"
                 url: "test_results/{{ whl_file_name }}"
+                metadata:
+                  version: "{{ global_env.RELEASE }}"
+                  python_version: "{{ global_env.PYTHON }}"
+                  is_cpu : 'true'
+      environment: '{{ global_env }}'
 
     - name: Verify Tensorflow whl package
       shell:

--- a/playbooks/tensorflow-arm-build/run.yaml
+++ b/playbooks/tensorflow-arm-build/run.yaml
@@ -237,7 +237,7 @@
     - name: Get whl file name
       find:
         paths: "{{ ansible_user_dir }}/workspace/test_results/"
-        patterns: 'tensorflow-*.whl'
+        patterns: 'tensorflow*.whl'
       register: file_name_matched
 
     - name: Set whl file name
@@ -261,7 +261,7 @@
           pip3 install numpy==1.18.0
           pip3 install keras_preprocessing
           sudo apt install libblas-dev liblapack-dev gfortran -y
-          pip3 install tensorflow-*.whl
+          pip3 install tensorflow*.whl
           python3 -c "import tensorflow as tf; print(tf.__version__)"
       args:
         executable: /bin/bash

--- a/playbooks/tensorflow-arm-build/run_release.yaml
+++ b/playbooks/tensorflow-arm-build/run_release.yaml
@@ -1,10 +1,5 @@
 - hosts: all
   tasks:
-    - name: debug all
-      debug:
-        msg: "--------------zuul {{ zuul }} -----------------"
-      environment: '{{ global_env }}'
-
     - name: collect artifacts to Zuul on version 1.15.3
       loop: "{{ zuul.artifacts }}"
       when:

--- a/playbooks/tensorflow-arm-build/run_release.yaml
+++ b/playbooks/tensorflow-arm-build/run_release.yaml
@@ -1,0 +1,32 @@
+- hosts: all
+  tasks:
+    - name: debug all
+      debug:
+        msg: "--------------zuul {{ zuul }} -----------------"
+      environment: '{{ global_env }}'
+
+    - name: collect artifacts to Zuul on version 1.15.3
+      loop: "{{ zuul.artifacts }}"
+      when:
+        - item.metadata.version == 'v1.15.3'
+        - global_env.RELEASE == 'v1.15.3'
+      zuul_return:
+        data:
+          zuul:
+            artifacts:
+              - name: "{{ item.name }}"
+                url: "{{ item.url }}"
+      environment: '{{ global_env }}'
+
+    - name: collect artifact to Zuul on version 2.1.0
+      loop: "{{ zuul.artifacts }}"
+      when:
+        - item.metadata.version == 'v2.1.0'
+        - global_env.RELEASE == 'v2.1.0'
+      zuul_return:
+        data:
+          zuul:
+            artifacts:
+              - name: "{{ item.name }}"
+                url: "{{ item.url }}"
+      environment: '{{ global_env }}'

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -2686,6 +2686,7 @@
         RELEASE: master
         BAZEL_VERSION: 3.1.0
         GCC_VERSION: default
+        PYTHON: v3.6
 
 - job:
     name: tensorflow-arm64-build-daily-v2.0.0
@@ -2697,6 +2698,7 @@
         RELEASE: v2.0.0
         BAZEL_VERSION: 0.26.0
         GCC_VERSION: default
+        PYTHON: v3.6
 
 - job:
     name: tensorflow-arm64-build-daily-v2.1.0
@@ -2708,3 +2710,98 @@
         RELEASE: v2.1.0
         BAZEL_VERSION: 0.29.1
         GCC_VERSION: 7.5.0
+        PYTHON: v3.6
+
+- job:
+    name: tensorflow-arm64-release-build-v1.15.3
+    parent: tensorflow-arm64-build-daily
+    description: |
+      Tensorflow v1.15.3 release build on ARM64
+    vars:
+      global_env:
+        RELEASE: v1.15.3
+        BAZEL_VERSION: 0.24.1
+        GCC_VERSION: default
+
+- job:
+    name: tensorflow-arm64-release-build-v1.15.3-py35
+    parent: tensorflow-arm64-release-build-v1.15.3
+    description: |
+      Tensorflow v1.15.3 release build on ARM64 with python3.5
+    vars:
+      global_env:
+        PYTHON: v3.5
+
+- job:
+    name: tensorflow-arm64-release-build-v1.15.3-py36
+    parent: tensorflow-arm64-release-build-v1.15.3
+    description: |
+      Tensorflow v1.15.3 release build on ARM64 with python3.6
+    vars:
+      global_env:
+        PYTHON: v3.6
+
+- job:
+    name: tensorflow-arm64-release-build-v1.15.3-py37
+    parent: tensorflow-arm64-release-build-v1.15.3
+    description: |
+      Tensorflow v1.15.3 release build on ARM64 with python3.7
+    vars:
+      global_env:
+        PYTHON: v3.7
+
+- job:
+    name: tensorflow-arm64-release-build-v1.15.3-py38
+    parent: tensorflow-arm64-release-build-v1.15.3
+    description: |
+      Tensorflow v1.15.3 release build on ARM64 with python3.8
+    vars:
+      global_env:
+        PYTHON: v3.8
+
+- job:
+    name: tensorflow-arm64-release-build-v2.1.0
+    parent: tensorflow-arm64-build-daily
+    description: |
+      Tensorflow v2.1.0 release build on ARM64
+    vars:
+      global_env:
+        RELEASE: v2.1.0
+        BAZEL_VERSION: 0.29.1
+        GCC_VERSION: 7.5.0
+
+- job:
+    name: tensorflow-arm64-release-build-v2.1.0-py35
+    parent: tensorflow-arm64-release-build-v2.1.0
+    description: |
+      Tensorflow v2.1.0 release build on ARM64 with python3.5
+    vars:
+      global_env:
+        PYTHON: v3.5
+
+- job:
+    name: tensorflow-arm64-release-build-v2.1.0-py36
+    parent: tensorflow-arm64-release-build-v2.1.0
+    description: |
+      Tensorflow v2.1.0 release build on ARM64 with python3.6
+    vars:
+      global_env:
+        PYTHON: v3.6
+
+- job:
+    name: tensorflow-arm64-release-build-v2.1.0-py37
+    parent: tensorflow-arm64-release-build-v2.1.0
+    description: |
+      Tensorflow v2.1.0 release build on ARM64 with python3.7
+    vars:
+      global_env:
+        PYTHON: v3.7
+
+- job:
+    name: tensorflow-arm64-release-build-v2.1.0-py38
+    parent: tensorflow-arm64-release-build-v2.1.0
+    description: |
+      Tensorflow v2.1.0 release build on ARM64 with python3.8
+    vars:
+      global_env:
+        PYTHON: v3.8

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -2732,6 +2732,7 @@
     parent: tensorflow-arm64-release-build-v1.15.3
     description: |
       Tensorflow v1.15.3 release build on ARM64 with python3.5
+    provides: tf-cpu-whl-ready-for-1.15.3-py35
     vars:
       global_env:
         PYTHON: v3.5
@@ -2741,6 +2742,7 @@
     parent: tensorflow-arm64-release-build-v1.15.3
     description: |
       Tensorflow v1.15.3 release build on ARM64 with python3.6
+    provides: tf-cpu-whl-ready-for-1.15.3-py36
     vars:
       global_env:
         PYTHON: v3.6
@@ -2750,18 +2752,10 @@
     parent: tensorflow-arm64-release-build-v1.15.3
     description: |
       Tensorflow v1.15.3 release build on ARM64 with python3.7
+    provides: tf-cpu-whl-ready-for-1.15.3-py37
     vars:
       global_env:
         PYTHON: v3.7
-
-- job:
-    name: tensorflow-arm64-release-build-v1.15.3-py38
-    parent: tensorflow-arm64-release-build-v1.15.3
-    description: |
-      Tensorflow v1.15.3 release build on ARM64 with python3.8
-    vars:
-      global_env:
-        PYTHON: v3.8
 
 - job:
     name: tensorflow-arm64-release-build-v2.1.0
@@ -2779,6 +2773,7 @@
     parent: tensorflow-arm64-release-build-v2.1.0
     description: |
       Tensorflow v2.1.0 release build on ARM64 with python3.5
+    provides: tf-cpu-whl-ready-for-2.1.0-py35
     vars:
       global_env:
         PYTHON: v3.5
@@ -2788,6 +2783,7 @@
     parent: tensorflow-arm64-release-build-v2.1.0
     description: |
       Tensorflow v2.1.0 release build on ARM64 with python3.6
+    provides: tf-cpu-whl-ready-for-2.1.0-py36
     vars:
       global_env:
         PYTHON: v3.6
@@ -2797,6 +2793,7 @@
     parent: tensorflow-arm64-release-build-v2.1.0
     description: |
       Tensorflow v2.1.0 release build on ARM64 with python3.7
+    provides: tf-cpu-whl-ready-for-2.1.0-py37
     vars:
       global_env:
         PYTHON: v3.7
@@ -2806,6 +2803,59 @@
     parent: tensorflow-arm64-release-build-v2.1.0
     description: |
       Tensorflow v2.1.0 release build on ARM64 with python3.8
+    provides: tf-cpu-whl-ready-for-2.1.0-py38
     vars:
       global_env:
         PYTHON: v3.8
+
+- job:
+    name: tensorflow-arm64-release-build-show
+    parent: init-test
+    description: |
+      Tensorflow release build whl download links on ARM64 with supported python versions.
+    run: playbooks/tensorflow-arm-build/run_release.yaml
+    nodeset: ubuntu-bionic-arm64-huaweicloud-8u16g
+    tags:
+      - Category:AI
+      - Project:Tensorflow/Tensorflow
+      - Application:Tensorflow@master
+      - OS:ubuntu-bionic
+      - Arch:arm64
+      - BuildType:Release
+    timeout: 54000
+
+- job:
+    name: tensorflow-v1.15.3-cpu-arm64-release-build-show
+    parent: tensorflow-arm64-release-build-show
+    description: |
+      Tensorflow CPU 1.15.3 release build whl download links on ARM64 with supported python versions.
+    requires:
+      - tf-cpu-whl-ready-for-1.15.3-py35
+      - tf-cpu-whl-ready-for-1.15.3-py36
+      - tf-cpu-whl-ready-for-1.15.3-py37
+    dependencies:
+      - tensorflow-arm64-release-build-v1.15.3-py35
+      - tensorflow-arm64-release-build-v1.15.3-py36
+      - tensorflow-arm64-release-build-v1.15.3-py37
+    vars:
+      global_env:
+        RELEASE: v1.15.3
+
+- job:
+    name: tensorflow-v2.1.0-cpu-arm64-release-build-show
+    parent: tensorflow-arm64-release-build-show
+    description: |
+      Tensorflow CPU 2.1.0 release build whl download links on ARM64 with supported python versions.
+    requires:
+      - tf-cpu-whl-ready-for-2.1.0-py35
+      - tf-cpu-whl-ready-for-2.1.0-py36
+      - tf-cpu-whl-ready-for-2.1.0-py37
+      - tf-cpu-whl-ready-for-2.1.0-py38
+    dependencies:
+      - tensorflow-arm64-release-build-v2.1.0-py35
+      - tensorflow-arm64-release-build-v2.1.0-py36
+      - tensorflow-arm64-release-build-v2.1.0-py37
+      - tensorflow-arm64-release-build-v2.1.0-py38
+    vars:
+      global_env:
+        RELEASE: v2.1.0

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -2709,7 +2709,7 @@
       global_env:
         RELEASE: v2.1.0
         BAZEL_VERSION: 0.29.1
-        GCC_VERSION: 7.5.0
+        GCC_VERSION: default
         PYTHON: v3.6
 
 - job:
@@ -2768,7 +2768,7 @@
       global_env:
         RELEASE: v2.1.0
         BAZEL_VERSION: 0.29.1
-        GCC_VERSION: 7.5.0
+        GCC_VERSION: default
 
 - job:
     name: tensorflow-arm64-release-build-v2.1.0-py35

--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -1457,3 +1457,19 @@
         to: dev@kudu.apache.org
         subject: Daily KUDU ARM64 Cron Job Test Result - FAILED
       mysql:
+
+# The pipelines below use for release CI system.
+# Right now, it only apply into tensorflow release CI system.
+- pipeline:
+    name: periodic-22-weekly-2-4-6
+    description: |
+      Jobs in this queue are triggered on a timer. UTC-22 22:00 on each Tuesday, Thursday and Saturday.
+    manager: independent
+    precedence: high
+    trigger:
+      timer:
+        - time: '0 22 * * 2,4,6'
+    success:
+      mysql:
+    failure:
+      mysql:

--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -509,6 +509,22 @@
     failure:
       mysql:
 
+# The pipelines below use for release CI system.
+# Right now, it only apply into tensorflow release CI system.
+- pipeline:
+    name: periodic-22-weekly-2-4-6
+    description: |
+      Jobs in this queue are triggered on a timer. UTC-22 22:00 on each Tuesday, Thursday and Saturday.
+    manager: independent
+    precedence: high
+    trigger:
+      timer:
+        - time: '0 22 * * 2,4,6'
+    success:
+      mysql:
+    failure:
+      mysql:
+
 - pipeline:
     name: recheck-designate
     description: |

--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -1457,19 +1457,3 @@
         to: dev@kudu.apache.org
         subject: Daily KUDU ARM64 Cron Job Test Result - FAILED
       mysql:
-
-# The pipelines below use for release CI system.
-# Right now, it only apply into tensorflow release CI system.
-- pipeline:
-    name: periodic-22-weekly-2-4-6
-    description: |
-      Jobs in this queue are triggered on a timer. UTC-22 22:00 on each Tuesday, Thursday and Saturday.
-    manager: independent
-    precedence: high
-    trigger:
-      timer:
-        - time: '0 22 * * 2,4,6'
-    success:
-      mysql:
-    failure:
-      mysql:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -265,8 +265,6 @@
             branches: master
         - tensorflow-arm64-release-build-v1.15.3-py37:
             branches: master
-        - tensorflow-arm64-release-build-v1.15.3-py38:
-            branches: master
         - tensorflow-arm64-release-build-v2.1.0-py35:
             branches: master
         - tensorflow-arm64-release-build-v2.1.0-py36:
@@ -274,6 +272,10 @@
         - tensorflow-arm64-release-build-v2.1.0-py37:
             branches: master
         - tensorflow-arm64-release-build-v2.1.0-py38:
+            branches: master
+        - tensorflow-v1.15.3-cpu-arm64-release-build-show:
+            branches: master
+        - tensorflow-v2.1.0-cpu-arm64-release-build-show:
             branches: master
 
 ####################### periodic jobs on 20:00##########################

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -257,6 +257,24 @@
             branches: master
         - tensorflow-arm64-build-daily-v2.1.0:
             branches: master
+    periodic-22-weekly-2-4-6:
+      jobs:
+        - tensorflow-arm64-release-build-v1.15.3-py35:
+            branches: master
+        - tensorflow-arm64-release-build-v1.15.3-py36:
+            branches: master
+        - tensorflow-arm64-release-build-v1.15.3-py37:
+            branches: master
+        - tensorflow-arm64-release-build-v1.15.3-py38:
+            branches: master
+        - tensorflow-arm64-release-build-v2.1.0-py35:
+            branches: master
+        - tensorflow-arm64-release-build-v2.1.0-py36:
+            branches: master
+        - tensorflow-arm64-release-build-v2.1.0-py37:
+            branches: master
+        - tensorflow-arm64-release-build-v2.1.0-py38:
+            branches: master
 
 ####################### periodic jobs on 20:00##########################
 - project:
@@ -293,16 +311,6 @@
 #            branches: master
 #        - rust-openstack-0.2.3-acceptance-queens:
 #            branches: master
-
-####################### weekly periodic jobs on 22:00##########################
-- project:
-    name: tensorflow/tensorflow
-    periodic-22-weekly-2-4-6:
-      jobs:
-        - tensorflow-arm64-release-build-v1.15.3:
-            branches: master
-        - tensorflow-arm64-release-build-v2.1.0:
-            branches: master
 
 ############# Temp ##############
 # - project:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -294,6 +294,15 @@
 #        - rust-openstack-0.2.3-acceptance-queens:
 #            branches: master
 
+####################### weekly periodic jobs on 22:00##########################
+- project:
+    name: tensorflow/tensorflow
+    periodic-22-weekly-2-4-6:
+      jobs:
+        - tensorflow-arm64-release-build-v1.15.3:
+            branches: master
+        - tensorflow-arm64-release-build-v2.1.0:
+            branches: master
 
 ############# Temp ##############
 # - project:


### PR DESCRIPTION
Add new pipeline for release CI.
Suport py35,py36,py37,py38 whl packages build.
Refactor the orig nightly build for fit all cases.

resolving-issues: https://github.com/theopenlab/openlab/issues/560 https://github.com/theopenlab/openlab/issues/559