### PR TITLE
Change the Kudu CI notification email address

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -1454,6 +1454,6 @@
     failure:
       smtp:
         from: info@openlabtesting.org
-        to: dev@kudu.apache.org
+        to: builds@kudu.apache.org
         subject: Daily KUDU ARM64 Cron Job Test Result - FAILED
       mysql:


### PR DESCRIPTION
Kudu community has added a builds@kudu.apache.org mailing list specific
for CI notifications, now the mailing list is OK to use, let change our
Kudu job.