### PR TITLE
Fix gpdb ci test env

### DIFF
--- a/playbooks/gpdb-installcheck-world-tests-on-arm64/run.yaml
+++ b/playbooks/gpdb-installcheck-world-tests-on-arm64/run.yaml
@@ -161,9 +161,9 @@
         executable: /bin/bash
         chdir: /home/zuul/gpdb
 
-    - name: debug
+    - name: Genarate local known_hosts for demo cluster startup
       shell: |
-        sleep 36000
+        ssh-keyscan -H `hostname` >> ~/.ssh/known_hosts
       args:
         executable: /bin/bash
 


### PR DESCRIPTION
In test env, I found it will inject the interaction during demo cluster
startup. So for forbid this issue, add the localhost signal into
known_hosts when the cluster setup the segment using hostname.