### PR TITLE
Pause tf 1.15 and 2.1.0 release Build

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -221,26 +221,26 @@
       jobs:
         - tensorflow-arm64-build-daily-master:
             branches: master
-    periodic-22-per-2-months:
-      jobs:
-        - tensorflow-arm64-release-build-v1.15.3-py35:
-            branches: master
-        - tensorflow-arm64-release-build-v1.15.3-py36:
-            branches: master
-        - tensorflow-arm64-release-build-v1.15.3-py37:
-            branches: master
-        - tensorflow-arm64-release-build-v2.1.0-py35:
-            branches: master
-        - tensorflow-arm64-release-build-v2.1.0-py36:
-            branches: master
-        - tensorflow-arm64-release-build-v2.1.0-py37:
-            branches: master
-        - tensorflow-arm64-release-build-v2.1.0-py38:
-            branches: master
-        - tensorflow-v1.15.3-cpu-arm64-release-build-show:
-            branches: master
-        - tensorflow-v2.1.0-cpu-arm64-release-build-show:
-            branches: master
+#     periodic-22-per-2-months:
+#       jobs:
+#         - tensorflow-arm64-release-build-v1.15.3-py35:
+#             branches: master
+#         - tensorflow-arm64-release-build-v1.15.3-py36:
+#             branches: master
+#         - tensorflow-arm64-release-build-v1.15.3-py37:
+#             branches: master
+#         - tensorflow-arm64-release-build-v2.1.0-py35:
+#             branches: master
+#         - tensorflow-arm64-release-build-v2.1.0-py36:
+#             branches: master
+#         - tensorflow-arm64-release-build-v2.1.0-py37:
+#             branches: master
+#         - tensorflow-arm64-release-build-v2.1.0-py38:
+#             branches: master
+#         - tensorflow-v1.15.3-cpu-arm64-release-build-show:
+#             branches: master
+#         - tensorflow-v2.1.0-cpu-arm64-release-build-show:
+#             branches: master
 
 ####################### periodic jobs on 20:00##########################
 - project:


### PR DESCRIPTION
Pause tf 1.15 and 2.1.0 release Build for not change the upstream aarch64 download url so frequently.

Will change to manually enable build per 2 months. As zuul doesn't know correct the time definition of the related pipeline.