### PR TITLE
[CPO] Update Go version to 1.15.0

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -523,7 +523,7 @@
       k8s_log_dir: '{{ ansible_user_dir }}/workspace/logs/kubernetes'
       kubectl: '{{ ansible_user_dir }}/src/k8s.io/kubernetes/cluster/kubectl.sh'
       cloud_name: citynetwork
-      go_version: '1.14.4'
+      go_version: '1.15.0'
 
 - job:
     name: cloud-provider-openstack-unittest
@@ -532,8 +532,6 @@
       Run unit test of cloud-provider-openstack
     run: playbooks/cloud-provider-openstack-unittest/run.yaml
     nodeset: ubuntu-xenial-citynetwork
-    vars:
-      go_version: '1.14.4'
     secrets:
       - citynetwork_credentials
 


### PR DESCRIPTION
This commit updates go version of CPO jobs to 1.15.0