### PR TITLE
Fix go version to 1.15

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -523,7 +523,7 @@
       k8s_log_dir: '{{ ansible_user_dir }}/workspace/logs/kubernetes'
       kubectl: '{{ ansible_user_dir }}/src/k8s.io/kubernetes/cluster/kubectl.sh'
       cloud_name: citynetwork
-      go_version: '1.15.0'
+      go_version: '1.15'
 
 - job:
     name: cloud-provider-openstack-unittest


### PR DESCRIPTION
1.15.0 version key is not found , needs to be updated to 1.15 to get downloaded.
This commit fix the same.