### PR TITLE
[CPO]Update default etcd server to 3.4.9

### DIFF
--- a/roles/install-k8s/defaults/main.yaml
+++ b/roles/install-k8s/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
 k8s_version: 'master'
-etcd_version: 'v3.4.7'
+etcd_version: 'v3.4.9'
 k8s_with_hyperkube:
   - release-1.10
   - release-1.11


### PR DESCRIPTION
Updates default etcd server to 3.4.9, which is default
version of k8s master