### PR TITLE
[CPO] Remove etcd server overwrites 3.4.9

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
@@ -2,8 +2,7 @@
   roles:
     - config-golang
     - export-cloud-openrc
-    - role: install-k8s
-      etcd_version: v3.4.9
+    - install-k8s
   become: yes
   tasks:
     - name: Run csi cinder acceptance tests with cloud-provider-openstack

--- a/playbooks/cloud-provider-openstack-acceptance-test-csi-manila/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-csi-manila/run.yaml
@@ -1,8 +1,7 @@
 - hosts: all
   roles:
     - config-golang
-    - role: install-k8s
-      etcd_version: v3.4.9
+    - install-k8s
     - clone-devstack-gate-to-workspace
     - role: create-devstack-local-conf
       enable_services:

--- a/playbooks/cloud-provider-openstack-e2e-test-csi-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-e2e-test-csi-cinder/run.yaml
@@ -2,8 +2,7 @@
   roles:
     - config-golang
     - export-cloud-openrc
-    - role: install-k8s
-      etcd_version: v3.4.9
+    - install-k8s
   become: yes
   tasks:
     - name: Run csi cinder e2e tests with cloud-provider-openstack


### PR DESCRIPTION
This PR is related to https://github.com/theopenlab/openlab-zuul-jobs/pull/972#issuecomment-675431409

The k8s master etcd server version `3.4.9` is set as default in https://github.com/theopenlab/openlab-zuul-jobs/pull/972/commits/340c7a8a191a8177cac1e68a27c4ea24343f0c05

Therefore the overwrites are removed as part of this PR.
<sub>Sean Schneeweiss <sean.schneeweiss@daimler.com>, Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sub>