### PR TITLE
[CPO] Make e2e conformance compatible with old releases

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -60,7 +60,8 @@
           export ARCH=amd64
           export IMAGE_NAMES=openstack-cloud-controller-manager
           export VERSION=latest
-          make build-images
+          # To be compatible with old releases, using make image-controller-manager
+          make image-controller-manager
 
           # The previous CPO makefile doesn't support arch
           docker image ls | grep "${IMAGE_NAMES}-${ARCH}"


### PR DESCRIPTION
1.17 e2e conformance jobs seems to fail to incompatible target, this PR is to fix the same.
build-images target is not compatible with old releases. 
ref: https://logs.openlabtesting.org/logs/periodic-14/github.com/kubernetes/cloud-provider-openstack/release-1.17/cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.17/18e79d8/job-output.json.gz