### PR TITLE
[CPO] Update csi cinder job

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
@@ -95,14 +95,6 @@
           '{{ kubectl }}' create clusterrolebinding --user system:serviceaccount:kube-system:shared-informers kube-system-cluster-admin-5 --clusterrole cluster-admin
           '{{ kubectl }}' create clusterrolebinding --user system:kube-controller-manager  kube-system-cluster-admin-6 --clusterrole cluster-admin
 
-          # Where csi provisioner reads instance id from
-          if [ -d /mnt/config/openstack ]; then
-              INSTANCE_UUID=$(python -c "import json;print json.load(open('/mnt/config/openstack/latest/meta_data.json', 'r'))['uuid']")
-          else
-              INSTANCE_UUID=$(curl http://169.254.169.254/openstack/latest/meta_data.json | python -c "import sys, json; print json.load(sys.stdin)['uuid']")
-          fi
-          echo "$INSTANCE_UUID" > /var/lib/cloud/data/instance-id
-
           # Get current branch name, convert to image tag, e.g. release-1.18 to v1.18.0
           branch="{{ zuul.branch }}"
           if [[ $branch == "master" ]]; then


### PR DESCRIPTION
As per the new code, we dont directly read from /var/lib/cloud/data
so, this part shouldnt be required.
This is with ref to failure : https://logs.openlabtesting.org/logs/80/1180/68a6e132902bde8c056a5ed1f4bc96b2f9c3d26e/cloud-provider-openstack-acceptance-test-csi-cinder/cloud-provider-openstack-acceptance-test-csi-cinder/02d96ee/job-output.json.gz