### PR TITLE
[CPO] update etcd version to 3.4.13

### DIFF
--- a/roles/install-k8s/defaults/main.yaml
+++ b/roles/install-k8s/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
 k8s_version: 'master'
-etcd_version: 'v3.4.9'
+etcd_version: 'v3.4.13'
 k8s_with_hyperkube:
   - release-1.10
   - release-1.11


### PR DESCRIPTION
Latest k8s version requires , etcd version 3.4.13, so updating the same.
https://logs.openlabtesting.org/logs/78/1178/219712789a23f596781f4493426effaeca3cc260/cloud-provider-openstack-acceptance-test-csi-cinder/cloud-provider-openstack-acceptance-test-csi-cinder/0c709f5/job-output.json.gz