### PR TITLE
Update terraform-provider-openstack repo link

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -86,7 +86,7 @@
     override-checkout: v1.19.0
     tags:
       - Category:Cloud
-      - Project:terraform-providers/terraform-provider-openstack
+      - Project:terraform-provider-openstack/terraform-provider-openstack
       - Application:terraform-provider-openstack@v1.19.0
       - Application:OpenStack@stein
       - Application:Go@1.12.1
@@ -112,7 +112,7 @@
     override-checkout: v1.19.0
     tags:
       - Category:Cloud
-      - Project:terraform-providers/terraform-provider-openstack
+      - Project:terraform-provider-openstack/terraform-provider-openstack
       - Application:terraform-provider-openstack@v1.19.0
       - Application:OpenStack@rocky
       - Application:Go@1.12.1
@@ -138,7 +138,7 @@
     override-checkout: v1.19.0
     tags:
       - Category:Cloud
-      - Project:terraform-providers/terraform-provider-openstack
+      - Project:terraform-provider-openstack/terraform-provider-openstack
       - Application:terraform-provider-openstack@v1.19.0
       - Application:OpenStack@queens
       - Application:Go@1.12.1
@@ -164,7 +164,7 @@
     override-checkout: v1.19.0
     tags:
       - Category:Cloud
-      - Project:terraform-providers/terraform-provider-openstack
+      - Project:terraform-provider-openstack/terraform-provider-openstack
       - Application:terraform-provider-openstack@v1.19.0
       - Application:OpenStack@pike
       - Application:Go@1.12.1
@@ -190,7 +190,7 @@
     override-checkout: v1.19.0
     tags:
       - Category:Cloud
-      - Project:terraform-providers/terraform-provider-openstack
+      - Project:terraform-provider-openstack/terraform-provider-openstack
       - Application:terraform-provider-openstack@v1.19.0
       - Application:OpenStack@ocata
       - Application:Go@1.12.1
@@ -216,7 +216,7 @@
     override-checkout: v1.19.0
     tags:
       - Category:Cloud
-      - Project:terraform-providers/terraform-provider-openstack
+      - Project:terraform-provider-openstack/terraform-provider-openstack
       - Application:terraform-provider-openstack@v1.19.0
       - Application:OpenStack@newton
       - Application:Go@1.12.1
@@ -243,7 +243,7 @@
 #    override-checkout: v1.19.0
 #    tags:
 #      - Category:Cloud
-#      - Project:terraform-providers/terraform-provider-openstack
+#      - Project:terraform-provider-openstack/terraform-provider-openstack
 #      - Application:terraform-provider-openstack@v1.19.0
 #      - Application:OpenStack@mitaka
 #      - Application:Go@1.12.1

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -72,7 +72,7 @@
 
 ####################### periodic jobs on 02:00 ##########################
 #- project:
-#    name: terraform-providers/terraform-provider-openstack
+#    name: terraform-provider-openstack/terraform-provider-openstack
 #    periodic-2:
 #      jobs:
 #        - terraform-provider-openstack-v1.19.0-acceptance-test-stein:


### PR DESCRIPTION
Use terraform-provider-openstack/terraform-provider-openstack as a
project tag.

This project was migrated to the new repository because of the changes
in Hashicorp Terraform providers releasing process.

All providers are moving to https://registry.terraform.io and
terraform-providers Github organization is deprecated.