### PR TITLE
[CPO] Enable CSI Snapshotter in e2e tests

### DIFF
--- a/playbooks/cloud-provider-openstack-e2e-test-csi-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-e2e-test-csi-cinder/run.yaml
@@ -50,6 +50,7 @@
           export ENABLE_HOSTPATH_PROVISIONER=true
           export ENABLE_SINGLE_CA_SIGNER=true
           export KUBE_ENABLE_CLUSTER_DNS=false
+          export ENABLE_CSI_SNAPSHOTTER=true
           export LOG_LEVEL=4
           # We want to use the openstack cloud provider
           export CLOUD_PROVIDER=openstack


### PR DESCRIPTION
Install CSI snapshotter in e2e tests , required to enable snapshot tests