### PR TITLE
[CPO] Skip more NodePort related conformance tests

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -188,7 +188,7 @@
             --test \
             --provider=skeleton \
             --ginkgo-parallel=1 \
-            --test_args="--ginkgo.focus=\\[Conformance\\] --ginkgo.noColor=true --ginkgo.skip=\\[sig\\-apps\\]\\sDaemon\\sset\\s\\[Serial\\]\\sshould\\srollback\\swithout\\sunnecessary\\srestarts\\s\\[Conformance\\]|\\[sig\\-network\\]\\sServices\\sshould\\sbe\\sable\\sto\\schange\\sthe\\stype\\sfrom\\sExternalName\\sto\\sNodePort\\s\\[Conformance\\]|\\[sig\\-network\\]\\sServices\\sshould\\sbe\\sable\\sto\\screate\\sa\\sfunctioning\\sNodePort\\sservice\\s\\[Conformance\\]" \
+            --test_args="--ginkgo.focus=\\[Conformance\\] --ginkgo.noColor=true --ginkgo.skip=\\[sig\\-apps\\]\\sDaemon\\sset\\s\\[Serial\\]\\sshould\\srollback\\swithout\\sunnecessary\\srestarts\\s\\[Conformance\\]|\\[sig\\-network\\]\\sServices\\sshould\\sbe\\sable\\sto\\schange\\sthe\\stype\\sfrom\\sExternalName\\sto\\sNodePort\\s\\[Conformance\\]|\\[sig\\-network\\]\\sServices\\sshould\\sbe\\sable\\sto\\screate\\sa\\sfunctioning\\sNodePort\\sservice\\s\\[Conformance\\]\\[sig\\-network\\]\\sServices\\sshould\\shave\\ssession\\saffinity\\swork\\sfor\\sNodePort\\sservice\\s\\[Conformance\\]\\[sig\\-network\\]\\sServices\\sshould\\sbe\\sable\\sto\\sswitch\\ssession\\saffinity\\sfor\\sNodePort\\sservice\\s\\[Conformance\\]\\[sig\\-network\\]\\sServices\\sshould\\shave\\ssession\\saffinity\\stimeout\\swork\\sfor\\sNodePort\\sservice\\s\\[Conformance\\]" \
             --extract ${K8S_VERSION} \
             --timeout=120m | tee $LOG_DIR/e2e.log
 


### PR DESCRIPTION
Skip the following NodePort related conformance tests because of the security group settings in the cloud provider (citynetwork):

```
2020-10-20 16:07:51.116698 | k8s-master | [Fail] [sig-network] Services [It] should have session affinity work for NodePort service [LinuxOnly] [Conformance]
2020-10-20 16:07:51.116731 | k8s-master | /workspace/anago-v1.19.3-rc.0.69+37babbd0e76c11/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:3511
2020-10-20 16:07:51.116766 | k8s-master |
2020-10-20 16:07:51.116854 | k8s-master | [Fail] [sig-network] Services [It] should be able to switch session affinity for NodePort service [LinuxOnly] [Conformance]
2020-10-20 16:07:51.116913 | k8s-master | /workspace/anago-v1.19.3-rc.0.69+37babbd0e76c11/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:3511
2020-10-20 16:07:51.116944 | k8s-master |
2020-10-20 16:07:51.116986 | k8s-master | [Fail] [sig-network] Services [It] should have session affinity timeout work for NodePort service [LinuxOnly] [Conformance]
2020-10-20 16:07:51.117022 | k8s-master | /workspace/anago-v1.19.3-rc.0.69+37babbd0e76c11/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:3444
```