### PR TITLE
Put native-toolchain check logs to test_results directory

### DIFF
--- a/playbooks/impala-build-test-arm64/run.yaml
+++ b/playbooks/impala-build-test-arm64/run.yaml
@@ -5,15 +5,23 @@
       shell: |
         set -o pipefail
         set -ex
+        
+        result_dir="{{ ansible_user_dir }}/workspace/test_results/"
+        mkdir -p "$result_dir"
 
         export IMPALA_HOME=`pwd`
 
         # we move native-toolchain from ~/ to IMPALA_HOME/..
         mv ~/native-toolchain $IMPALA_HOME/..
 
-        ./bin/bootstrap_development.sh
-
         RET_CODE=0
+        if ! bin/bootstrap_development.sh; then
+          RET_CODE=1
+        fi
+        cp $IMPALA_HOME/../native-toolchain/check "$result_dir"
+  
+        exit $RET_CODE
+        
         if ! bin/run-all-tests.sh; then
           RET_CODE=1
         fi


### PR DESCRIPTION
Impala job failed when build kudu, so keep related logs to check.