### PR TITLE
CPO: Set required env variables in conformance test

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -184,6 +184,9 @@
           mkdir -p '{{ k8s_log_dir }}'
           export LOG_DIR='{{ k8s_log_dir }}'
           sudo chmod 777 $LOG_DIR
+          export KUBE_MASTER_IP=$(ip route get 1.1.1.1 | awk '{print $7}')
+          export KUBE_MASTER=k8s-master
+          export DUMP_ONLY_MASTER_LOGS=true
 
           kubetest --dump=$LOG_DIR \
             --test \
@@ -191,7 +194,7 @@
             --ginkgo-parallel=1 \
             --test_args="--ginkgo.focus=\\[Conformance\\] --ginkgo.noColor=true --ginkgo.v=true --ginkgo.trace=true --disable-log-dump=true --ginkgo.skip=\\[sig\\-apps\\]\\sDaemon\\sset\\s\\[Serial\\]\\sshould\\srollback\\swithout\\sunnecessary\\srestarts\\s\\[Conformance\\]|\\[sig\\-network\\]\\sServices\\sshould\\sbe\\sable\\sto\\schange\\sthe\\stype\\sfrom\\sExternalName\\sto\\sNodePort\\s\\[Conformance\\]|\\[sig\\-network\\]\\sServices\\sshould\\sbe\\sable\\sto\\screate\\sa\\sfunctioning\\sNodePort\\sservice\\s\\[Conformance\\]|\\[sig\\-network\\]\\sServices\\sshould\\shave\\ssession\\saffinity\\swork\\sfor\\sNodePort\\sservice\\s\\[LinuxOnly\\]\\s\\[Conformance\\]|\\[sig\\-network\\]\\sServices\\sshould\\sbe\\sable\\sto\\sswitch\\ssession\\saffinity\\sfor\\sNodePort\\sservice\\s\\[LinuxOnly\\]\\s\\[Conformance\\]|\\[sig\\-network\\]\\sServices\\sshould\\shave\\ssession\\saffinity\\stimeout\\swork\\sfor\\sNodePort\\sservice\\s\\[LinuxOnly\\]\\s\\[Conformance\\]" \
             --extract ${K8S_VERSION} \
-            --timeout=200m | tee $LOG_DIR/e2e.log
+            --timeout=150m | tee $LOG_DIR/e2e.log
 
     - name: Run image build and publish for cloud-provider-openstack
       shell:


### PR DESCRIPTION
Dumping logs on master is failing due to unset variables of KUBE_MASTER 

2020-11-19 16:13:12.858162 | k8s-master | Dumping logs from master locally to '/home/zuul/workspace/logs/kubernetes'
2020-11-19 16:13:12.858754 | k8s-master | KUBE_MASTER_IP:
2020-11-19 16:13:12.858800 | k8s-master | KUBE_MASTER:
2020-11-19 16:13:12.859247 | k8s-master | ./cluster/log-dump/log-dump.sh: line 343: MASTER_NAME: unbound variable

https://logs.openlabtesting.org/logs/periodic-14/github.com/kubernetes/cloud-provider-openstack/master/cloud-provider-openstack-acceptance-test-e2e-conformance/0828ff0/job-output.txt.gz

This PR sets the env variables to master ip.
