### PR TITLE
CPO: Set MASTER_NAME as well explicitly.

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -186,6 +186,7 @@
           sudo chmod 777 $LOG_DIR
           export KUBE_MASTER_IP=$(ip route get 1.1.1.1 | awk '{print $7}')
           export KUBE_MASTER=k8s-master
+          export MASTER_NAME=k8s-master
           export DUMP_ONLY_MASTER_LOGS=true
 
           kubetest --dump=$LOG_DIR \


### PR DESCRIPTION
This PR sets the MASTER_NAME explicitly because of error
2020-11-19 16:13:12.859247 | k8s-master | ./cluster/log-dump/log-dump.sh: line 343: MASTER_NAME: unbound variable
