### PR TITLE
Add missing no-log to install-devstack

### DIFF
--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -104,6 +104,7 @@
       echo "{$openrc}"
     executable: /bin/bash
   register: output
+  no_log: yes
 
 - name: Set fact for devstack openrc
   set_fact:


### PR DESCRIPTION
Assuming we don't want openrc contents to be logged, echoing it should be no_log as well.