### PR TITLE
Upgrade CPO cinder test jobs image from xenial to bionic

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -833,7 +833,7 @@
       Run cinder csi acceptance tests of cloud-provider-openstack
     run: playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
     post-run: playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/post.yaml
-    nodeset: ubuntu-xenial-citynetwork
+    nodeset: ubuntu-bionic-citynetwork
     secrets:
       - citynetwork_credentials
       - swr
@@ -845,7 +845,7 @@
       Run cinder csi e2e tests of cloud-provider-openstack
     run: playbooks/cloud-provider-openstack-e2e-test-csi-cinder/run.yaml
     post-run: playbooks/cloud-provider-openstack-e2e-test-csi-cinder/post.yaml
-    nodeset: ubuntu-xenial-citynetwork
+    nodeset: ubuntu-bionic-citynetwork
     secrets:
       - citynetwork_credentials
       - swr


### PR DESCRIPTION
Resolve issue: https://github.com/theopenlab/openlab/issues/667

Due to `cloud-provider-openstack-acceptance-test-csi-manila` and `cloud-provider-openstack-acceptance-test-keystone-authentication-authorization` are already ubuntu bionic images.

So this time, upgrade `cloud-provider-openstack-acceptance-test-csi-cinder` and `cloud-provider-openstack-e2e-test-csi-cinder` testnodes from 1604 to 1804.