### PR TITLE
Upgrade ubuntu focal x86 image for CPO

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -833,7 +833,7 @@
       Run cinder csi acceptance tests of cloud-provider-openstack
     run: playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
     post-run: playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/post.yaml
-    nodeset: ubuntu-bionic-citynetwork
+    nodeset: ubuntu-focal-citynetwork
     secrets:
       - citynetwork_credentials
       - swr
@@ -845,7 +845,7 @@
       Run cinder csi e2e tests of cloud-provider-openstack
     run: playbooks/cloud-provider-openstack-e2e-test-csi-cinder/run.yaml
     post-run: playbooks/cloud-provider-openstack-e2e-test-csi-cinder/post.yaml
-    nodeset: ubuntu-bionic-citynetwork
+    nodeset: ubuntu-focal-citynetwork
     secrets:
       - citynetwork_credentials
       - swr
@@ -883,7 +883,7 @@
       Run manila csi acceptance tests of cloud-provider-openstack
     run: playbooks/cloud-provider-openstack-acceptance-test-csi-manila/run.yaml
     post-run: playbooks/cloud-provider-openstack-acceptance-test-csi-manila/post.yaml
-    nodeset: ubuntu-bionic
+    nodeset: ubuntu-focal
     secrets:
       - swr
 
@@ -910,7 +910,7 @@
     description: |
       Run keystone auth acceptance tests of cloud-provider-openstack
     run: playbooks/cloud-provider-openstack-acceptance-test-keystone-authentication-authorization/run.yaml
-    nodeset: ubuntu-bionic
+    nodeset: ubuntu-focal
     secrets:
       - swr
 

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -120,3 +120,21 @@
     nodes:
       - name: impala-arm64-build-test
         label: ubuntu-bionic-arm64-huaweicloud-impala
+
+- nodeset:
+    name: ubuntu-focal
+    nodes:
+      - name: ubuntu-focal
+        label: ubuntu-focal
+
+- nodeset:
+    name: ubuntu-focal-large
+    nodes:
+      - name: ubuntu-focal-large
+        label: ubuntu-focal-large
+
+- nodeset:
+    name: ubuntu-focal-citynetwork
+    nodes:
+      - name: ubuntu-focal-citynetwork
+        label: ubuntu-focal-citynetwork


### PR DESCRIPTION
upgrade  `cloud-provider-openstack-acceptance-test-csi-cinder`, `cloud-provider-openstack-e2e-test-csi-cinder`, `cloud-provider-openstack-acceptance-test-csi-manila` and `cloud-provider-openstack-acceptance-test-keystone-authentication-authorization` from ubuntu 1804 to 2004

Affected issue: https://github.com/theopenlab/openlab/issues/667