### PR TITLE
[CPO] Include host name in /etc/hosts

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -33,6 +33,16 @@
       hostname:
         name: "{{ inventory_hostname }}"
 
+    - name: hostname in /etc/hosts
+      lineinfile:
+        dest=/etc/hosts
+        regexp='.*{{ item }}$'
+        line="{{ hostvars[item].ansible_default_ipv4.address }} {{item}}"
+        state=present
+      when: hostvars[item].ansible_default_ipv4.address is defined
+      loop:
+        - "{{ inventory_hostname }}"
+
     - name: ship /etc/default/kubelet
       copy:
         dest: /etc/default/kubelet


### PR DESCRIPTION
The multi-node k8s cluster installation is still failed because:

```
2021-02-03 01:34:35.626590 | k8s-node-2 | 	[WARNING Hostname]: hostname "k8s-node-2" could not be reached
2021-02-03 01:34:35.626691 | k8s-node-2 | 	[WARNING Hostname]: hostname "k8s-node-2": lookup k8s-node-2 on 127.0.0.1:53: no such host
```

This patch makes sure the hostname is present in /etc/hosts.