### PR TITLE
[CPO] Fix the k8s cluster installation for cpo e2e conformance test

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -57,7 +57,7 @@
       lineinfile:
         dest=/etc/hosts
         regexp='^127\.0\.1\.1'
-        line=127.0.1.1 {{ hostname_output.stdout }}
+        line='127.0.1.1 {{ hostname_output.stdout }}'
         state=present
 
     - name: ship /etc/default/kubelet

--- a/roles/create-multinodes-k8s-cluster-with-kubeadm/tasks/main.yaml
+++ b/roles/create-multinodes-k8s-cluster-with-kubeadm/tasks/main.yaml
@@ -76,7 +76,6 @@
     fi
     kubelet --version
     apt-mark hold kubelet kubeadm kubectl
-    sleep 7200
     {{ kubeadm_join_cmd }}
     # for NFS pvc
     apt-get install -y nfs-common


### PR DESCRIPTION
The PR (and the previous several ones) fixes the job
cloud-provider-openstack-acceptance-test-e2e-conformance by:

1. Getting hostname from Nova metadata service (default is ubuntu)
2. Changing hostname for the nodes