### PR TITLE
Revert "Add missing no-log to install-devstack (#1062)"

### DIFF
--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -111,7 +111,6 @@
       echo "{$openrc}"
     executable: /bin/bash
   register: output
-  no_log: yes
 
 - name: Set fact for devstack openrc
   set_fact:


### PR DESCRIPTION
This reverts commit 30ffe4b62a41037d08491aaccf7c39f2b1b2e1a7.

Terraform and gophercloud jobs are failing on this task[1], and the
no_log hides the actual error.  We don't really need a no_log
here since this openrc is for a throwaway test cloud -- the password
that is being hidden is the literal string "password" so there's
no secret info.

[1] https://github.com/theopenlab/openlab/issues/681