### PR TITLE
[all]: Apply the pip constraints fix into the devstack-vm-gate-wrap.sh for Ubuntu Focal

### DIFF
--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -65,9 +65,10 @@
   shell:
     cmd: |
       # workaround for bug https://bugs.launchpad.net/devstack/+bug/1906322
-      rm -f /opt/stack/new/devstack/tools/cap-pip.txt
-      sed -i 's|  "$flags|  "# $name filtered. Installed from local source:|g' /opt/stack/new/devstack/inc/python
-      sed -i 's|sudo -H -E python.*|sudo -H -E python${PYTHON3_VERSION} $LOCAL_PIP|g' /opt/stack/new/devstack/tools/install_pip.sh
+      sed -i '/"Running gate_hook"/ a\
+      rm -f /opt/stack/new/devstack/tools/cap-pip.txt\
+      sed -i '\''s|  "$flags|  "# $name filtered. Installed from local source:|g'\'' /opt/stack/new/devstack/inc/python\
+      sed -i '\''s|sudo -H -E python.*|sudo -H -E python${PYTHON3_VERSION} $LOCAL_PIP|g'\'' /opt/stack/new/devstack/tools/install_pip.sh' '{{ ansible_user_dir }}/workspace/devstack-gate/devstack-vm-gate-wrap.sh'
     executable: /bin/bash
   when: ansible_distribution_release == "focal"
 


### PR DESCRIPTION
Followup for the #1105

The `/opt/stack/new/devstack` file is available only within the `Install devstack on {{ global_env.OS_BRANCH }} branch` task. So we need to run sed inside the `devstack-gate/devstack-vm-gate-wrap.sh` script.

/assign @bzhaoopenstack @wangxiyuan @jeblair @emonty @lingxiankong 