### PR TITLE
[CPO] Fix random failure when setting hostname

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-csi-cinder/run.yaml
@@ -1,46 +1,14 @@
 - hosts: all
-  name: workaround to set up hostname
   become: yes
 
-  tasks:
-    - name: Make sure the utility packages are installed
-      apt:
-        name: "{{ packages }}"
-        state: present
-        update_cache: yes
-      vars:
-        packages:
-          - jq
-
-    # Nova VMs created in citynetwork use ubuntu as the default hostname, should be changed to the VM name so that
-    # the kubernetes node could be initialized.
-    - name: Get instance hostname from Nova metadata service
-      shell:
-        executable: /bin/bash
-        cmd: |
-          nova_hostname=$(curl -sS http://169.254.169.254/openstack/latest/meta_data.json | jq -r '.hostname')
-          echo ${nova_hostname%%.novalocal}
-      register: hostname_output
-
-    - name: Set hostname
-      hostname:
-        name: "{{ hostname_output.stdout }}"
-
-    - name: hostname in /etc/hosts
-      lineinfile:
-        dest: /etc/hosts
-        regexp: '^127\.0\.1\.1'
-        line: '127.0.1.1 {{ hostname_output.stdout }}'
-        state: present
-
-- hosts: all
   roles:
+    - cloud-instance-hostname
     - config-golang
     - export-cloud-openrc
     - role: install-k8s
       vars:
         customize_docker_version: '20.10'
-  become: yes
+
   tasks:
     - name: Prepare base alpine image
       shell:

--- a/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-e2e-conformance/run.yaml
@@ -28,38 +28,10 @@
   name: kubelet cloud-provider external
   become: yes
 
+  roles:
+    - cloud-instance-hostname
+
   tasks:
-    - name: Make sure the utility packages are installed
-      apt:
-        name: "{{ packages }}"
-        state: present
-        update_cache: yes
-      vars:
-        packages:
-          - build-essential
-          - jq
-
-    # Nova VMs created in citynetwork use ubuntu as the default hostname, should be changed to the VM name so that
-    # the kubernetes node could be initialized.
-    - name: Get instance hostname from Nova metadata service
-      shell:
-        executable: /bin/bash
-        cmd: |
-          nova_hostname=$(curl -sS http://169.254.169.254/openstack/latest/meta_data.json | jq -r '.hostname')
-          echo ${nova_hostname%%.novalocal}
-      register: hostname_output
-
-    - name: Set hostname
-      hostname:
-        name: "{{ hostname_output.stdout }}"
-
-    - name: hostname in /etc/hosts
-      lineinfile:
-        dest=/etc/hosts
-        regexp='^127\.0\.1\.1'
-        line='127.0.1.1 {{ hostname_output.stdout }}'
-        state=present
-
     - name: ship /etc/default/kubelet
       copy:
         dest: /etc/default/kubelet

--- a/playbooks/cloud-provider-openstack-multinode-csi-migration-test/pre.yaml
+++ b/playbooks/cloud-provider-openstack-multinode-csi-migration-test/pre.yaml
@@ -1,36 +1,10 @@
-# Nova VMs created in citynetwork use ubuntu as the default hostname, should be changed to the VM name so that
-# the kubernetes node could be initialized.
 - hosts: all
-  name: workaround setting host and collecting data
+  name: workaround setting hostname and create /etc/hosts
   become: true
-  tasks:
-    - name: get hostname from openstack
-      uri:
-        url: http://169.254.169.254/openstack/latest/meta_data.json
-        method: GET
-        body_format: json
-      register: os_meta_data
 
-    - name: setting os_hostname
-      set_fact:
-        os_hostname: "{{ os_meta_data.json.hostname.split('.') | first }}"
+  roles:
+    - cloud-instance-hostname
 
-    - name: detecting os_hostname
-      debug:
-        var: os_hostname
-
-    - name: old hostname to be replaced
-      debug:
-        var: ansible_hostname
-
-    - name: set hostname
-      hostname:
-        name: "{{ os_hostname }}"
-        use: systemd
-
-- hosts: all
-  name: workaround create /etc/hosts
-  become: true
   tasks:
     - name: new hostname
       debug:

--- a/roles/cloud-instance-hostname/tasks/main.yml
+++ b/roles/cloud-instance-hostname/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+- name: Hostname | Make sure the utility packages are installed
+  apt:
+    name: "{{ packages }}"
+    state: present
+    update_cache: yes
+  vars:
+    packages:
+      - build-essential
+      - jq
+
+# Nova VMs created in citynetwork use ubuntu as the default hostname, should be changed to the VM name so that
+# the kubernetes node could be initialized.
+- name: Hostname | Get instance hostname from Nova metadata service
+  shell:
+    executable: /bin/bash
+    cmd: |
+      nova_hostname=$(curl -sS http://169.254.169.254/openstack/latest/meta_data.json | jq -r '.hostname')
+      echo ${nova_hostname%%.novalocal}
+  register: hostname_output
+
+- name: Hostname | Set hostname
+  hostname:
+    name: "{{ hostname_output.stdout }}"
+    use: debian
+
+- name: Hostname | Set hostname in /etc/hosts
+  lineinfile:
+    dest=/etc/hosts
+    regexp='^127\.0\.1\.1'
+    line='127.0.1.1 {{ hostname_output.stdout }}'
+    state=present


### PR DESCRIPTION
The error:
```
2021-02-07 11:28:36.785301 | TASK [Set hostname]
2021-02-07 11:28:37.671930 | k8s-node-1 | ERROR
2021-02-07 11:28:37.672460 | k8s-node-1 | {
2021-02-07 11:28:37.672606 | k8s-node-1 |   "msg": "Command failed rc=1, out=, err=Failed to create bus connection: No such file or directory\n"
2021-02-07 11:28:37.672692 | k8s-node-1 | }
2021-02-07 11:28:37.821684 | k8s-master | changed
2021-02-07 11:28:37.852968 | k8s-node-2 | changed
```

This PR moves the setting hostname function into a role.