### PR TITLE
devstack task: ERROR: Cannot uninstall 'simplejson'

### DIFF
--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -65,9 +65,11 @@
   shell:
     cmd: |
       # workaround for bug https://bugs.launchpad.net/devstack/+bug/1906322
+      # workaround for bug https://bugs.launchpad.net/devstack/+bug/1791892
       sed -i '/"Running gate_hook"/ a\
       rm -f /opt/stack/new/devstack/tools/cap-pip.txt\
       sed -i '\''s|  "$flags|  "# $name filtered. Installed from local source:|g'\'' /opt/stack/new/devstack/inc/python\
+      sed -i '\''s|$cmd_pip $upgrade |$cmd_pip $upgrade --ignore-installed |g'\'' /opt/stack/new/devstack/inc/python\
       sed -i '\''s|sudo -H -E python.*|sudo -H -E python${PYTHON3_VERSION} $LOCAL_PIP|g'\'' /opt/stack/new/devstack/tools/install_pip.sh' '{{ ansible_user_dir }}/workspace/devstack-gate/devstack-vm-gate-wrap.sh'
     executable: /bin/bash
   when: ansible_distribution_release == "focal"


### PR DESCRIPTION
Another devstack python patch for Ubuntu Focal.

https://logs.openlabtesting.org/logs/84/1384/a2a6c42d771b29e4a364b78145904ec971e28072/cloud-provider-openstack-acceptance-test-keystone-authentication-authorization/cloud-provider-openstack-acceptance-test-keystone-authentication-authorization/a5331a1/logs/devstacklog.txt

```
2021-02-09 07:28:24.178 | Installing collected packages: requestsexceptions, munch, jsonpatch, jmespath, simplejson, openstacksdk, python-novaclient, python-cinderclient, osc-lib, python-openstackclient
2021-02-09 07:28:24.211 |   Attempting uninstall: jsonpatch
2021-02-09 07:28:24.212 |     Found existing installation: jsonpatch 1.22
2021-02-09 07:28:24.215 |     Uninstalling jsonpatch-1.22:
2021-02-09 07:28:24.245 |       Successfully uninstalled jsonpatch-1.22
2021-02-09 07:28:24.295 |   Attempting uninstall: simplejson
2021-02-09 07:28:24.296 |     Found existing installation: simplejson 3.16.0
2021-02-09 07:28:24.296 | ERROR: Cannot uninstall 'simplejson'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.
2021-02-09 07:28:24.392 | WARNING: You are using pip version 21.0; however, version 21.0.1 is available.
2021-02-09 07:28:24.392 | You should consider upgrading via the '/usr/bin/python3.8 -m pip install --upgrade pip' command.
```

/assign @bzhaoopenstack @wangxiyuan @jeblair @emonty @lingxiankong

can we merge this right away? It is not quite convenient to wait 24h, then face yest another bug in devstack task. Otherwise we'll can spend weeks on these clumsy python requirements issues.