### PR TITLE
[occm]: install python3-pip on focal

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-keystone-authentication-authorization/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-keystone-authentication-authorization/run.yaml
@@ -31,7 +31,8 @@
           # Build cloud-provider-openstack binaries
           make build
 
-          apt-get install python-pip -y
+          # if python-pip cannot be found, install python3-pip
+          apt-get install python-pip -y || apt-get install python3-pip -y
           pip install -U python-openstackclient
 
           # Create cloud-config


### PR DESCRIPTION
Task: https://logs.openlabtesting.org/logs/84/1384/a2a6c42d771b29e4a364b78145904ec971e28072/cloud-provider-openstack-acceptance-test-keystone-authentication-authorization/cloud-provider-openstack-acceptance-test-keystone-authentication-authorization/bba5fc1/job-output.txt.gz

Error:

```
2021-02-09 08:58:40.811199 | ubuntu-focal | + apt-get install python-pip -y
2021-02-09 08:58:40.874150 | ubuntu-focal | Reading package lists...
2021-02-09 08:58:40.989569 | ubuntu-focal | Building dependency tree...
2021-02-09 08:58:40.990325 | ubuntu-focal | Reading state information...
2021-02-09 08:58:41.104459 | ubuntu-focal | E: Unable to locate package python-pip
2021-02-09 08:58:41.507686 | ubuntu-focal | ERROR
```

@wangxiyuan another fix for a package name