### PR TITLE
Role cloud-instance-hostname: use systemd strategy to update hostname

### DIFF
--- a/roles/cloud-instance-hostname/tasks/main.yml
+++ b/roles/cloud-instance-hostname/tasks/main.yml
@@ -22,7 +22,7 @@
 - name: Hostname | Set hostname
   hostname:
     name: "{{ hostname_output.stdout }}"
-    use: debian
+    use: systemd
 
 - name: Hostname | Set hostname in /etc/hosts
   lineinfile:


### PR DESCRIPTION
To fix:

```
2021-02-09 03:16:00.151186 | TASK [cloud-instance-hostname : Hostname | Set hostname]
2021-02-09 03:16:01.266271 | ubuntu-focal-citynetwork | ERROR
2021-02-09 03:16:01.266737 | ubuntu-focal-citynetwork | {
2021-02-09 03:16:01.266833 | ubuntu-focal-citynetwork |   "msg": "Command failed rc=1, out=, err=\u001b[0;1;31mUnknown operation ubuntu-focal-citynetwork-citynetwork-openlab-0000149931.\u001b[0m\n"
2021-02-09 03:16:01.266923 | ubuntu-focal-citynetwork | }
```

fixes #676
