### PR TITLE
Fixed installation of ansible-lint

### DIFF
--- a/playbooks/openlab-zuul-jobs-check/run.yaml
+++ b/playbooks/openlab-zuul-jobs-check/run.yaml
@@ -35,8 +35,9 @@
           set -o pipefail
           set -x
           export ANSIBLE_ACTION_PLUGINS=/opt/zuul/zuul/ansible/base/actiongeneral
+          export CRYPTOGRAPHY_DONT_BUILD_RUST=1
 
-          pip install ansible-lint
+          pip install ansible-lint[core]
           find playbooks -type f -regex '.*.y[a]?ml' -not -path "{{ excluded_path }}" -print0 | xargs -t -n1 -0 ansible-lint -x106,203,204,207,208,301,206,305,303,405
           find playbooks -type f -regex '.*.y[a]?ml' -not -path "{{ excluded_path }}" -exec ansible-playbook -v --syntax-check -i ./playbooks/openlab-zuul-jobs-check/inventory \{\} + > /dev/null
         executable: /bin/bash


### PR DESCRIPTION
ansible-lint released version 5.0.0 what doesn't depend hard on ansible
any more. This PR installs ansible-lint[core] that does depend on
ansible.
See
https://github.com/ansible-community/ansible-lint/blob/650bc07fc4cbd05f9a98ea614589f907e965c61d/setup.cfg#L96