### PR TITLE
Fix openlab-check job

### DIFF
--- a/playbooks/openlab-zuul-jobs-check/run.yaml
+++ b/playbooks/openlab-zuul-jobs-check/run.yaml
@@ -37,7 +37,7 @@
           export ANSIBLE_ACTION_PLUGINS=/opt/zuul/zuul/ansible/base/actiongeneral
           export CRYPTOGRAPHY_DONT_BUILD_RUST=1
 
-          pip install ansible-lint[core]
+          pip install ansible-lint==4.3.7
           find playbooks -type f -regex '.*.y[a]?ml' -not -path "{{ excluded_path }}" -print0 | xargs -t -n1 -0 ansible-lint -x106,203,204,207,208,301,206,305,303,405
           find playbooks -type f -regex '.*.y[a]?ml' -not -path "{{ excluded_path }}" -exec ansible-playbook -v --syntax-check -i ./playbooks/openlab-zuul-jobs-check/inventory \{\} + > /dev/null
         executable: /bin/bash


### PR DESCRIPTION
The upstream ansible-lint has been upgraded to 5.0.1 version. And request the min version of ansible is 2.9.0 .
Openlab ansible runtime is 2.8.0 version, and all the jobs code with 2.8.0 syntax and format, so for ansible-lint, we can not upgrade to the latest version(5.0.1) directly.

And from my test, there are several obvious bugs towards the latest version, such as the `skip_list` doesn't work (expect is exchanging by ErrId), `tag_list` can only use the said newer names, and the initial check error in https://github.com/ansible-community/ansible-lint/blob/master/src/ansiblelint/_prerun.py#L39 (If we had a installed ansible version, the code would be failure.) . So I think the upstream software quality of ansible-lint is unavailable. We need to wait until the software is stable before upgrading the ansible version.

So current solution is keeping to use the old version(4.3.7), which is latest version for 4.X . The differences between ansible-lint 5.0.1 and ansible 4.3.7 are very big, the same as ansible 2.9 and ansible 2.8 .

Associated-Bugs: https://github.com/theopenlab/openlab/issues/689