### PR TITLE
[cpo] Added e2e.log to e2e-test-csi-cinder

### DIFF
--- a/playbooks/cloud-provider-openstack-e2e-test-csi-cinder/run.yaml
+++ b/playbooks/cloud-provider-openstack-e2e-test-csi-cinder/run.yaml
@@ -213,7 +213,7 @@
 
           # Download kubectl binary
           curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x /usr/local/bin/kubectl
-              go test -v ./cmd/tests/cinder_csi_e2e_suite_test.go -ginkgo.v -ginkgo.progress -ginkgo.skip="\[Disruptive\]" -ginkgo.focus="\[cinder-csi-e2e\]" -timeout=0 -report-dir='{{ k8s_log_dir }}'
+          go test -v ./cmd/tests/cinder_csi_e2e_suite_test.go -ginkgo.v -ginkgo.progress -ginkgo.skip="\[Disruptive\]" -ginkgo.focus="\[cinder-csi-e2e\]" -ginkgo.noColor -timeout=0 -report-dir='{{ k8s_log_dir }}' | tee "{{ k8s_log_dir }}/e2e.log"
 
         executable: /bin/bash
         chdir: '{{ k8s_os_provider_src_dir }}'


### PR DESCRIPTION
This file will be uploaded after the run, and debugging failed runs will
be simpler for us.