### PR TITLE
[CPO] Update go version to 1.16

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -541,7 +541,7 @@
       k8s_log_dir: '{{ ansible_user_dir }}/workspace/logs/kubernetes'
       kubectl: '{{ ansible_user_dir }}/src/k8s.io/kubernetes/cluster/kubectl.sh'
       cloud_name: citynetwork
-      go_version: '1.15'
+      go_version: '1.16'
 
 - job:
     name: cloud-provider-openstack-unittest


### PR DESCRIPTION
1.16 go version required for CPO jobs. This PR updates the same.