### PR TITLE
[CPO] Add signal file for PR label

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/post.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/post.yaml
@@ -5,16 +5,8 @@
     KUBECONFIG: "{{ ansible_user_dir }}/.kube/config"
 
   tasks:
-    - name: Clean up k8s services
-      shell:
-        executable: /bin/bash
-        cmd: |
-          set -o pipefail
-          services=$(kubectl -n octavia-lb-test get svc -o json | jq -r '.items[] | .metadata.name')
-          for i in $services; do kubectl -n octavia-lb-test delete svc $i; done
-          # Sleep 10s to make sure occm finishes deleting all the cloud resources.
-          sleep 10
-
-    - name: Remove PR label for openstack-cloud-controller-manager
+    - name: Removv openstack-cloud-controller-manager PR label only if the signal file exsits.
       shell: kubectl -n kube-system label ds openstack-cloud-controller-manager PR-
+      args:
+        removes: "{{ ansible_user_dir }}/pr_label.signal"
       ignore_errors: True

--- a/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
@@ -82,13 +82,14 @@
       retries: 30
       delay: 10
 
-    - name: Update openstack-cloud-controller-manager with the new docker image and add testing label
+    - name: Update openstack-cloud-controller-manager image and add PR label if signal file doesn't exist
       shell:
         executable: /bin/bash
         cmd: |
           export KUBECONFIG={{ ansible_user_dir }}/.kube/config
           kubectl -n kube-system set image daemonset/openstack-cloud-controller-manager openstack-cloud-controller-manager=swr.ap-southeast-3.myhuaweicloud.com/openlab/openstack-cloud-controller-manager:{{ zuul.change }}
           kubectl -n kube-system label daemonset openstack-cloud-controller-manager PR={{ zuul.change }}
+        creates: "{{ ansible_user_dir }}/pr_label.signal"
 
     - name: Wait for openstack-cloud-controller-manager up and running
       shell:


### PR DESCRIPTION
When job A is running but the PR label was set by another job B, the job A should wait. However, if the waiting times out, job A shouldn't remove the label which was set by another job.

The Kubernetes resources should be cleaned up by the script itself in CPO repo.