### PR TITLE
Fix the ansible role cloud-instance-hostname

### DIFF
--- a/roles/cloud-instance-hostname/tasks/main.yml
+++ b/roles/cloud-instance-hostname/tasks/main.yml
@@ -19,6 +19,11 @@
       echo ${nova_hostname%%.novalocal}
   register: hostname_output
 
+- name: Hostname | Ensure dbus installation as a dependency of hostnamectl
+  apt:
+    name: dbus
+    state: present
+
 - name: Hostname | Set hostname
   hostname:
     name: "{{ hostname_output.stdout }}"


### PR DESCRIPTION
The ansible role cloud-instance-hostname is quite unstable, it fails randomly with the following error:

```
2021-03-19 05:18:52.064876 | TASK [cloud-instance-hostname : Hostname | Set hostname]
2021-03-19 05:18:52.989693 | k8s-node-2 | ERROR
2021-03-19 05:18:52.990325 | k8s-node-2 | {
2021-03-19 05:18:52.990415 | k8s-node-2 |   "msg": "Command failed rc=1, out=, err=Failed to create bus connection: No such file or directory\n"
2021-03-19 05:18:52.990490 | k8s-node-2 | }
```

This PR fixes this issue by making sure dbus is installed before setting hostname by the `hostname` ansible module. Please see more discussion in https://github.com/ansible/ansible/issues/25543 and https://github.com/ansible/ansible/pull/55516