### PR TITLE
[TF-OS] Add new playbook for admin user

### DIFF
--- a/playbooks/terraform-provider-openstack-acceptance-test-admin/run.yaml
+++ b/playbooks/terraform-provider-openstack-acceptance-test-admin/run.yaml
@@ -1,0 +1,47 @@
+- hosts: all
+  become: yes
+  roles:
+    - config-golang
+    - clone-devstack-gate-to-workspace
+    - role: create-devstack-local-conf
+      enable_services:
+        - 'manila'
+        - 'designate'
+        - 'neutron-ext'
+    - install-devstack
+  tasks:
+    - name: Run acceptance tests with terraform-provider-openstack
+      shell:
+        cmd: |
+          set -e
+          set -o pipefail
+          set -x
+          # Prep the testing environment by creating the required testing resources and environment variables
+          pushd /opt/stack/new/devstack
+          source openrc admin admin
+          openstack flavor create m1.acctest --id 99 --ram 512 --disk 5 --vcpu 1 --ephemeral 10
+          openstack flavor create m1.resize --id 98 --ram 512 --disk 6 --vcpu 1 --ephemeral 10
+          _NETWORK_ID=$(openstack network show private -c id -f value)
+          _EXTGW_ID=$(openstack network show public -c id -f value)
+          _IMAGE=$(openstack image list | grep -i cirros | head -n 1)
+          _IMAGE_ID=$(echo $_IMAGE | awk -F\| '{print $2}' | tr -d ' ')
+          _IMAGE_NAME=$(echo $_IMAGE | awk -F\| '{print $3}' | tr -d ' ')
+          echo export OS_IMAGE_NAME="$_IMAGE_NAME" >> openrc
+          echo export OS_IMAGE_ID="$_IMAGE_ID" >> openrc
+          echo export OS_NETWORK_ID=$_NETWORK_ID >> openrc
+          echo export OS_EXTGW_ID=$_EXTGW_ID >> openrc
+          echo export OS_POOL_NAME="public" >> openrc
+          echo export OS_FLAVOR_ID=99 >> openrc
+          echo export OS_FLAVOR_ID_RESIZE=98 >> openrc
+          echo export OS_DOMAIN_ID=default >> openrc
+          source openrc admin admin
+          popd
+
+          # Run except the DNS/FW/LB test 100 testcases at a time
+          export OS_SWIFT_ENVIRONMENT=1 # for Swift tests
+          testcases=`go test ./openstack/ -v -list 'Acc'`
+          testcases=`echo "$testcases" | sed '$d' | grep -v -e FW -e LB`
+          echo "$testcases" | xargs -t -n100 sh -c 'OS_DEBUG=1 TF_LOG=DEBUG TF_ACC=1 go test ./openstack -v -timeout 120m -run $(echo "$@" | tr " " "|")' argv0 2>&1 | tee $TEST_RESULTS_TXT
+        executable: /bin/bash
+        chdir: '{{ zuul.project.src_dir }}'
+      environment: '{{ global_env }}'

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -94,6 +94,18 @@
     vars:
       go_version: '1.14'
 
+### job that runs with admin creds
+- job:
+    name: terraform-provider-openstack-acceptance-test-admin
+    parent: golang-test-main
+    description: |
+      Run terraform-provider-openstack acceptance test against master OpenStack with admin creds
+    run: playbooks/terraform-provider-openstack-acceptance-test-admin/run.yaml
+    nodeset: ubuntu-bionic
+    timeout: 21600
+    vars:
+      go_version: '1.14'
+
 ### son job against stein branch of OpenStack
 - job:
     name: terraform-provider-openstack-acceptance-test-stein


### PR DESCRIPTION
This commit creates a new job for the terraform-openstack-provider.
The job runs with admin credentials allowing to test scenarios that
require admin credentials.

This is a follow-up from https://github.com/theopenlab/openlab/issues/365 and relates to https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1211