### PR TITLE
[cpo] upload results of csi e2e to testgrid

### DIFF
--- a/playbooks/cloud-provider-openstack-e2e-test-csi-cinder/post.yaml
+++ b/playbooks/cloud-provider-openstack-e2e-test-csi-cinder/post.yaml
@@ -1,13 +1,10 @@
-- hosts: all
+- hosts: k8s-master
+  name: Upload e2e test result
   become: yes
-  tasks:
-    - name: Clean up resources for csi cinder e2e tests
-      shell:
-        cmd: |
-          set -e
-          set -x
-          '{{ kubectl }}' config use-context local
-          '{{ kubectl }}' delete -f manifests/cinder-csi-plugin
-        executable: /bin/bash
-        chdir: '{{ k8s_os_provider_src_dir }}'
-      environment: '{{ global_env }}'
+
+  roles:
+    - export-gcp-account
+    - role: upload-testgrid
+      vars:
+        upload_testgrid_bucket_name: k8s-conform-provider-openstack
+        upload_testgrid_key_file: "{{ gcp_cpo_key_file }}"

--- a/roles/upload-testgrid/tasks/main.yml
+++ b/roles/upload-testgrid/tasks/main.yml
@@ -1,0 +1,31 @@
+- name: Upload E2E test result to kubernetes testgrid
+  environment: '{{ global_env }}'
+  ignore_errors: yes  # the test run should not fail when upload doesnt work
+  shell:
+    executable: /bin/bash
+    cmd: |
+      set -ex
+
+      # install gsutil, upload_e2e.py depends on it
+      export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
+      echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+      curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add
+      apt-get update && sudo apt-get install google-cloud-sdk --yes
+      apt-get install google-cloud-sdk-app-engine-java --yes
+
+      # get upload_e2e.py
+      wget https://raw.githubusercontent.com/kubernetes/test-infra/master/testgrid/conformance/upload_e2e.py
+
+      # TODO(RuiChen): Add timestamp for e2e.log in order to workaround upload_e2e.py bug
+      export LOG_DIR="{{ k8s_log_dir }}"
+      date  +"%b %e %H:%M:%S.999: DONE" >> $LOG_DIR/e2e.log
+
+      PIPELINE_LOGS_DIR='pr-logs'
+      if [[ '{{ zuul.pipeline }}' =~ ^periodic ]]; then
+          PIPELINE_LOGS_DIR='periodic-logs'
+      fi
+
+      # upload e2e log to new google storage bucket.
+      python3.7 upload_e2e.py --junit=$LOG_DIR/junit*.xml --log=$LOG_DIR/e2e.log \
+          --bucket=gs://{{ upload_testgrid_bucket_name }}/$PIPELINE_LOGS_DIR/ci-'{{ zuul.job }}' \
+          --key-file='{{ upload_testgrid_key_file }}'


### PR DESCRIPTION
We plan to include results of
cloud-provider-openstack-e2e-test-csi-cinder to be available in
testgrid. This PR uploads the results of the job so that testgrid can
visualize it.

The removed cleanup didn't cleanup anything real. So removed it.