### PR TITLE
Disable iscsi in ironic devstack conf

### DIFF
--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -285,7 +285,7 @@
       IRONIC_VM_LOG_DIR=/opt/stack/new/ironic-bm-logs
       IRONIC_VM_SPECS_RAM=384
       IRONIC_DEFAULT_DEPLOY_INTERFACE=direct
-      IRONIC_ENABLED_DEPLOY_INTERFACES=iscsi,direct
+      IRONIC_ENABLED_DEPLOY_INTERFACES=direct
       SWIFT_ENABLE_TEMPURLS=True
       SWIFT_TEMPURL_KEY=secretkey
       EOF


### PR DESCRIPTION
iSCSI support was removed from ironic in
https://review.opendev.org/c/openstack/ironic/+/789382, and
ironic-conductor can no longer start with this present in the config.

Fixes: gophercloud/gophercloud#2155