### PR TITLE
Additional logging if OCCM fails to start

### DIFF
--- a/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
+++ b/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml
@@ -104,6 +104,26 @@
       until: check_pod.rc == 0
       retries: 24
       delay: 5
+      ignore_errors: yes
+
+    - name: Gather additional evidence if openstack-cloud-controller-manager failed to come up
+      when: check_pod.failed
+      block:
+        - name: Describe failed openstack-cloud-controller-manager
+          shell:
+            executable: /bin/bash
+            cmd: |
+              kubectl -n kube-system describe daemonset openstack-cloud-controller-manager
+          register: describe_occm
+          changed_when: false
+
+        - name: Log failed openstack-cloud-controller-manager daemonset
+          debug:
+            var: describe_occm.stdout_lines
+
+        - name: &failmsg Stop due to prior failure of openstack-cloud-controller-manager
+          fail:
+            msg: *failmsg
 
     - name: Run acceptance tests for LoadBalancer Service
       shell:


### PR DESCRIPTION
Warning! I'm not able to test this locally! All I know for sure is that ansible-lint is happy with my changes.

I'm hoping this will give additional context to failures such as: https://logs.openlabtesting.org/logs/28/1528/39ea9b7a68866d6cb3ecec7431761b5ff0731aad/cloud-provider-openstack-acceptance-test-lb-octavia/cloud-provider-openstack-acceptance-test-lb-octavia/c5f119b/job-output.txt.gz