### PR TITLE
cleanup for orphaned volumes of cinder csi

### DIFF
--- a/playbooks/cloud-provider-openstack-cleanup-volumes/run.yaml
+++ b/playbooks/cloud-provider-openstack-cleanup-volumes/run.yaml
@@ -1,0 +1,6 @@
+- name: cleanup orphaned volumes
+  hosts: all
+  become: yes
+  roles:
+    - export-cloud-openrc
+    - cleanup-cinder-csi-volumes

--- a/roles/cleanup-cinder-csi-volumes/files/cleanup_volumes.py
+++ b/roles/cleanup-cinder-csi-volumes/files/cleanup_volumes.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+This script removes volumes created by cinder csi that are
+* older than 3 hours
+* not attached to any node
+"""
+import openstack
+import logging
+import sys
+from datetime import datetime, timedelta
+
+def main():
+
+    logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+    log = logging.getLogger(__name__)
+    log.info("cleaning up orphaned volumes")
+
+    con = openstack.connect()
+    volumes = con.block_storage.volumes(details=True, status="available")
+
+    for v in filter(filter_volumes, volumes):
+        log.info("deleting volume %s", v.id)
+        try:
+            con.block_storage.delete_volume(v, ignore_missing=True)
+        except:
+            log.exception("unable to delete volume %s... skipping", v.id)
+            pass
+
+def filter_volumes(vol):
+    """
+    filter_volumes takes care to only clean up volumes created by cinder csi
+    """
+    try:
+        if not vol.name.startswith("pvc-"):
+            return False
+        if vol.attachments:
+            return False
+
+        created = datetime.fromisoformat(vol.created_at)
+        age = datetime.now() - created
+        if age < timedelta(hours=3):
+            return False
+
+        cluster_name = vol.metadata.get("cinder.csi.openstack.org/cluster", "")
+        if not cluster_name.startswith("kubernetes"):
+            return False
+    except:
+        return False
+    return True
+
+if __name__ == "__main__":
+    main()

--- a/roles/cleanup-cinder-csi-volumes/tasks/main.yml
+++ b/roles/cleanup-cinder-csi-volumes/tasks/main.yml
@@ -1,0 +1,12 @@
+- name: isntall openstacksdk
+  apt:
+    name: python3-openstacksdk
+
+- name: copy cleanup_volumes.py
+  copy:
+    src: cleanup_volumes.py
+    dest: /tmp/cleanup_volumes.py
+    mode: "0755"
+
+- name: call cleanup_volumes.py
+  command: python3 /tmp/cleanup_volumes.py

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -901,6 +901,16 @@
       - swr
 
 - job:
+    name: cloud-provider-openstack-cleanup-volumes
+    parent: init-test
+    description: |
+      Cleanup orphaned resources of volume tests
+    run: playbooks/cloud-provider-openstack-cleanup-volumes/run.yaml
+    nodeset: ubuntu-focal-citynetwork
+    secrets:
+      - citynetwork_credentials
+
+- job:
     name: cloud-provider-openstack-acceptance-test-manila-provisioner
     parent: cloud-provider-openstack-test
     description: |

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -187,6 +187,10 @@
             branches: master
 
 ####################### periodic jobs on 22:00##########################
+- project:
+    periodic-22:
+      jobs:
+        - cloud-provider-openstack-cleanup-volumes
 
 ####################### periodic jobs on 2:00 per Sunday##########################
 - project:


### PR DESCRIPTION
Discussed in https://github.com/theopenlab/openlab/issues/746

This PR runs a job periodically to remove orphaned volumes created by
cinder csi. Post cleanup jobs directly on the real test jobs are not
robust enough in cases of e.g. timeouts or random crashes.