### PR TITLE
[CPO] Use cloud-provider-openstack-test-occm as base job

### DIFF
--- a/playbooks/cloud-provider-openstack-test-occm-e2e-conformance/run.yaml
+++ b/playbooks/cloud-provider-openstack-test-occm-e2e-conformance/run.yaml
@@ -48,7 +48,7 @@
         name: install-k3s-vm
       vars:
         devstack_workdir: "{{ global_env.devstack_workdir }}"
-        cpo_branch: "{{ zuul.branch }}"
+        k8s_branch: "{{ k8s_release | default(zuul.branch) }}"
         worker_node_count: 2
 
     - name: Deploy openstack-cloud-controller-manager

--- a/playbooks/cloud-provider-openstack-test-occm/run-1.19.yaml
+++ b/playbooks/cloud-provider-openstack-test-occm/run-1.19.yaml
@@ -48,7 +48,7 @@
         name: install-k3s-vm
       vars:
         devstack_workdir: "{{ global_env.devstack_workdir }}"
-        cpo_branch: "{{ zuul.branch }}"
+        k8s_branch: "{{ k8s_release | default(zuul.branch) }}"
         worker_node_count: 1
 
     - name: Deploy openstack-cloud-controller-manager

--- a/playbooks/cloud-provider-openstack-test-occm/run-1.20.yaml
+++ b/playbooks/cloud-provider-openstack-test-occm/run-1.20.yaml
@@ -48,7 +48,7 @@
         name: install-k3s-vm
       vars:
         devstack_workdir: "{{ global_env.devstack_workdir }}"
-        cpo_branch: "{{ zuul.branch }}"
+        k8s_branch: "{{ k8s_release | default(zuul.branch) }}"
         worker_node_count: 1
 
     - name: Deploy openstack-cloud-controller-manager

--- a/playbooks/cloud-provider-openstack-test-occm/run-1.21.yaml
+++ b/playbooks/cloud-provider-openstack-test-occm/run-1.21.yaml
@@ -48,7 +48,7 @@
         name: install-k3s-vm
       vars:
         devstack_workdir: "{{ global_env.devstack_workdir }}"
-        cpo_branch: "{{ zuul.branch }}"
+        k8s_branch: "{{ k8s_release | default(zuul.branch) }}"
         worker_node_count: 1
 
     - name: Deploy openstack-cloud-controller-manager

--- a/playbooks/cloud-provider-openstack-test-occm/run.yaml
+++ b/playbooks/cloud-provider-openstack-test-occm/run.yaml
@@ -48,7 +48,7 @@
         name: install-k3s-vm
       vars:
         devstack_workdir: "{{ global_env.devstack_workdir }}"
-        cpo_branch: "{{ zuul.branch }}"
+        k8s_branch: "{{ k8s_release | default(zuul.branch) }}"
         worker_node_count: 1
 
     - name: Deploy openstack-cloud-controller-manager

--- a/roles/install-k3s-vm/defaults/main.yaml
+++ b/roles/install-k3s-vm/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-cpo_branch: "master"
+k8s_branch: "master"
 worker_node_count: 0
 cluster_token: "9a08jv.c0izixklcxtmnze7"
 devstack_workdir: "{{ ansible_user_dir }}/devstack"

--- a/roles/install-k3s-vm/tasks/main.yaml
+++ b/roles/install-k3s-vm/tasks/main.yaml
@@ -2,8 +2,8 @@
   shell:
     executable: /bin/bash
     cmd: |
-      # Get k3s release based on the CPO branch.
-      branch={{ cpo_branch }}
+      # Get k3s release based on the given k8s branch.
+      branch={{ k8s_branch }}
       if [[ "$branch" = "master" ]]; then
         k3s_release=$(curl -s "https://api.github.com/repos/k3s-io/k3s/tags" | jq -r '.[0].name')
       else

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -841,24 +841,17 @@
 
 - job:
     name: cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.21
-    parent: cloud-provider-openstack-acceptance-test-e2e-conformance
+    parent: cloud-provider-openstack-test-occm-e2e-conformance
     description: |
-      Run Kubernetes E2E Conformance tests against release-1.21 branch of Kubernetes
-    nodeset: ubuntu-xenial-k8s-cluster-cpo
+      Run Kubernetes E2E Conformance tests against v1.21 release of Kubernetes(k3s)
+    nodeset: ubuntu-focal-large
     vars:
-      go_version: '1.15'
-      k8s_version: 'release-1.21'
-      etcd_version: 'v3.4.13'
-      kubernetes_version: 'v1.21.0'
+      k8s_release: 'release-1.21'
     tags:
       - Category:Cloud
       - Project:kubernetes/cloud-provider-openstack
       - Application:cloud-provider-openstack@release-1.21
       - Application:Kubernetes@release-1.21
-      - Application:Docker.io@v18.09
-      - Application:Etcd@v3.4.13
-      - Application:Go@1.15
-      - OS:ubuntu-xenial
       - Arch:x86_64
       - BuildType:Integration test
 


### PR DESCRIPTION
This change only affects cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.21