### PR TITLE
Add a workaround to avoid issues when devstack needs APT

### DIFF
--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -1,3 +1,8 @@
+# We don't want the system crontabs, some of them run APT and it can cause
+# problems when devstack also needs to run APT at the same time.
+- name: Workaround to disable all root crontabs
+  command: crontab -r
+
 - name: Workaround for devstack installation in Newton or earlier
   shell:
     cmd: |


### PR DESCRIPTION
It's rare but it can happen that devstack runs at the same time as a
crontab is triggered and runs APT to e.g. execute unattended upgrades of
the system.

Devstack would fail since APT isn't available.
This patch adds a workaround so it'll remove the crontabs before
deploying devstack.
