### PR TITLE
openlab-zuul-jobs-check: upgrade the host before git clone zuul

### DIFF
--- a/playbooks/openlab-zuul-jobs-check/run.yaml
+++ b/playbooks/openlab-zuul-jobs-check/run.yaml
@@ -22,6 +22,7 @@
           set -x
           apt install -y python3.7-dev libre2-dev
           apt remove -y python3-yaml
+          apt upgrade -y
           git clone https://opendev.org/zuul/zuul.git
           cd zuul
           pip3 install -e .


### PR DESCRIPTION
We need the latest certificates on the host; which can be done by
upgrading the system.

Currently, zuul repo can't be cloned for that job because of this error:

```
fatal: unable to access 'https://opendev.org/zuul/zuul.git/': server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none
```
