### PR TITLE
openlab-zuul-jobs-check: ignore SSL errors when cloning zuul

### DIFF
--- a/playbooks/openlab-zuul-jobs-check/run.yaml
+++ b/playbooks/openlab-zuul-jobs-check/run.yaml
@@ -22,8 +22,7 @@
           set -x
           apt install -y python3.7-dev libre2-dev
           apt remove -y python3-yaml
-          apt upgrade -y
-          git clone https://opendev.org/zuul/zuul.git
+          GIT_SSL_NO_VERIFY=true git clone https://opendev.org/zuul/zuul.git
           cd zuul
           pip3 install -e .
         executable: /bin/bash


### PR DESCRIPTION
Currently, zuul repo can't be cloned for that job because of this error:

```
fatal: unable to access 'https://opendev.org/zuul/zuul.git/': server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none
```

Let's ignore the SSL error for now.
