### PR TITLE
Revert "Add a workaround to avoid issues when devstack needs APT"

### DIFF
--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -1,8 +1,3 @@
-# We don't want the system crontabs, some of them run APT and it can cause
-# problems when devstack also needs to run APT at the same time.
-- name: Workaround to disable all root crontabs
-  command: crontab -r
-
 - name: Workaround for devstack installation in Newton or earlier
   shell:
     cmd: |


### PR DESCRIPTION
```
2021-11-02 16:54:58.373348 | TASK [install-devstack : Workaround to disable all root crontabs]
2021-11-02 08:55:00.133765 | ubuntu-focal | no crontab for root
2021-11-02 16:55:10.647948 | ubuntu-focal | ERROR
2021-11-02 16:55:10.648164 | ubuntu-focal | {
2021-11-02 16:55:10.648206 | ubuntu-focal |   "delta": "0:00:00.009216",
2021-11-02 16:55:10.648233 | ubuntu-focal |   "end": "2021-11-02 08:55:00.135359",
2021-11-02 16:55:10.648256 | ubuntu-focal |   "msg": "non-zero return code",
2021-11-02 16:55:10.648278 | ubuntu-focal |   "rc": 1,
2021-11-02 16:55:10.648299 | ubuntu-focal |   "start": "2021-11-02 08:55:00.126143"
2021-11-02 16:55:10.648319 | ubuntu-focal | }
```

This isn't working as expected, it'll need more work.