### PR TITLE
install-devstack: allow to extend ENV for devstack specifics

### DIFF
--- a/roles/install-devstack/defaults/main.yaml
+++ b/roles/install-devstack/defaults/main.yaml
@@ -1,2 +1,3 @@
 ---
 openrc_file: '/opt/stack/new/devstack/openrc'
+devstack_env: {}

--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -112,7 +112,7 @@
       iptables -F openstack-INPUT || true
     executable: /bin/bash
     chdir: '{{ ansible_user_dir }}/workspace'
-  environment: '{{ zuul | zuul_legacy_vars }}'
+  environment: '{{ zuul | zuul_legacy_vars | combine(devstack_env|default({})) }}'
 
 - name: Remove distutils packages that conflict with pip packages that devstack needs to install
   apt:


### PR DESCRIPTION
Adding `devstack_env` variable, when set it'll merge with Zuul
environment for running devstack. It can help when we want to customize
Devstack install.
