### PR TITLE
Use devstack_env into create-devstack-local-conf role

### DIFF
--- a/roles/create-devstack-local-conf/defaults/main.yaml
+++ b/roles/create-devstack-local-conf/defaults/main.yaml
@@ -6,3 +6,4 @@ enable_services:
   - 'keystone'
   - 'glance'
   - 'swift'
+devstack_env: {}

--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -292,3 +292,19 @@
     executable: /bin/bash
   when:
     - '"ironic" in enable_services'
+
+- name: Allow to override local vars for devstack
+  when: devstack_env is defined
+  block:
+  - name: create temporary file for devstack overrides
+    template:
+      src: "devstack_overrides.conf.j2"
+      dest: "/tmp/dg-local-overrides.conf"
+      mode: '0644'
+  - name: add the overrides to /tmp/dg-local.conf
+    shell:
+      cmd: |
+        set -e
+        set -x
+        cat /tmp/dg-local-overrides.conf >> /tmp/dg-local.conf
+      executable: /bin/bash

--- a/roles/create-devstack-local-conf/templates/devstack_overrides.conf.j2
+++ b/roles/create-devstack-local-conf/templates/devstack_overrides.conf.j2
@@ -1,0 +1,8 @@
+# {{ ansible_managed }}:
+# devstack overrides for specific needs
+
+{% for key, value in devstack_env.items() %}
+{{ key }}: {{ value }}
+{% endfor %}
+
+# END of devstack overrides

--- a/roles/install-devstack/defaults/main.yaml
+++ b/roles/install-devstack/defaults/main.yaml
@@ -1,3 +1,2 @@
 ---
 openrc_file: '/opt/stack/new/devstack/openrc'
-devstack_env: {}

--- a/roles/install-devstack/tasks/main.yml
+++ b/roles/install-devstack/tasks/main.yml
@@ -112,7 +112,7 @@
       iptables -F openstack-INPUT || true
     executable: /bin/bash
     chdir: '{{ ansible_user_dir }}/workspace'
-  environment: '{{ zuul | zuul_legacy_vars | combine(devstack_env|default({})) }}'
+  environment: '{{ zuul | zuul_legacy_vars }}'
 
 - name: Remove distutils packages that conflict with pip packages that devstack needs to install
   apt:


### PR DESCRIPTION
If devstack_env is set, we'll add the environment variables into the
local config for devstack. This will be useful for anyone who wants to
configure devstack for their needs, in the CI jobs.

This is backward compatible and disabled by default.
