### PR TITLE
create-devstack-local-conf: skip overrides if devstack_env is empty

### DIFF
--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -294,7 +294,8 @@
     - '"ironic" in enable_services'
 
 - name: Allow to override local vars for devstack
-  when: devstack_env is defined
+  when:
+    - (devstack_env | length) > 0
   block:
   - name: create temporary file for devstack overrides
     template:


### PR DESCRIPTION
In my previous patch, I missed the fact that we set a default for
`devstack_env`. This patch will helps to make the playbook faster, if we
don't need to run the block. If the variable is an empty dic, we'll skip
the block as there is no need to configure overrides.
