### PR TITLE
create-devstack-local-conf: fix a typo in the template

### DIFF
--- a/roles/create-devstack-local-conf/templates/devstack_overrides.conf.j2
+++ b/roles/create-devstack-local-conf/templates/devstack_overrides.conf.j2
@@ -2,7 +2,7 @@
 # devstack overrides for specific needs
 
 {% for key, value in devstack_env.items() %}
-{{ key }}: {{ value }}
+{{ key }}={{ value }}
 {% endfor %}
 
 # END of devstack overrides


### PR DESCRIPTION
This is bash environment, not YAML. Sorry for the typo.
