### PR TITLE
Make sure we uninstall unattended-upgrades on Ubuntu

### DIFF
--- a/playbooks/init-test/pre.yaml
+++ b/playbooks/init-test/pre.yaml
@@ -13,3 +13,10 @@
         path: "/etc/hosts"
         regexp: "^127.0.0.1"
         line: "127.0.0.1 {{ result.stdout }} localhost"
+
+    - name: Uninstall unattended-upgrades
+      become: true
+      package:
+        name: unattended-upgrades
+        state: absent
+      when: ansible_distribution == "Ubuntu"


### PR DESCRIPTION
unattended-upgrades package in Ubuntu sets up a crontab that will
periodically upgrade the system and therefore run "apt".

We don't want that because it'll lock apt so things like devstack will
fail since they won't be able to use apt.

Let's just remove the package if installed, which is how other infras
are doing.
