### PR TITLE
Add a role to prefetch Amphora from RDO server

### DIFF
--- a/roles/prefetch-amphora/README.md
+++ b/roles/prefetch-amphora/README.md
@@ -1,0 +1,6 @@
+Pre-fetch the Amphora image from an URL into a specific directory.
+
+## Roles variables
+
+* `amphora_url`: URL of the Amphora image to download
+* `amphora_dir`: Directory where the image will be downloaded

--- a/roles/prefetch-amphora/defaults/main.yaml
+++ b/roles/prefetch-amphora/defaults/main.yaml
@@ -1,0 +1,3 @@
+amphora_url: https://images.rdoproject.org/octavia/master/amphora-x64-haproxy-centos.qcow2
+amphora_dir: /opt/octavia-amphora
+amphora_file_name: amphora-x64-haproxy.qcow2

--- a/roles/prefetch-amphora/tasks/main.yaml
+++ b/roles/prefetch-amphora/tasks/main.yaml
@@ -1,0 +1,11 @@
+- name: Create a directory for the Octavia Amphora image
+  file:
+    path: "{{ amphora_dir }}"
+    state: directory
+    mode: 0755
+
+- name: Download the image into the directory
+  get_url:
+    url: "{{ amphora_url }}"
+    dest: "{{ amphora_dir }}/{{ amphora_file_name }}"
+    mode: 0755


### PR DESCRIPTION
Instead of building Amphora, allow to download it from a place (default
is RDO), into a specific directory.

This will save time for some jobs where Octavia devstack plugin builds
the Amphora image.
