### PR TITLE
Add support for vpnaas

### DIFF
--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -222,6 +222,18 @@
   when:
     - '"fwaas-v2" in enable_services'
 
+- name: create devstack local conf with vpnaas enabled
+  shell:
+    cmd: |
+      set -e
+      set -x
+      cat << EOF >> /tmp/dg-local.conf
+      enable_plugin neutron-vpnaas https://opendev.org/openstack/neutron-vpnaas
+      EOF
+    executable: /bin/bash
+  when:
+    - '"vpnaas" in enable_services'
+
 - name: create devstack local conf with zun enabled
   shell:
     cmd: |


### PR DESCRIPTION
Allows enable neutron-vpnaas with default values by adding `vpnaas` to
`enable_services`.

https://docs.openstack.org/neutron-vpnaas/latest/contributor/devstack.html