### PR TITLE
Do not force master branch for magnum

### DIFF
--- a/roles/create-devstack-local-conf/tasks/main.yml
+++ b/roles/create-devstack-local-conf/tasks/main.yml
@@ -262,7 +262,7 @@
       set -e
       set -x
       cat << EOF >> /tmp/dg-local.conf
-      enable_plugin magnum https://opendev.org/openstack/magnum master
+      enable_plugin magnum https://opendev.org/openstack/magnum
       EOF
     executable: /bin/bash
   when:


### PR DESCRIPTION
We were mistakenly setting the checkout branch to master.